### PR TITLE
feat: Modal 컴포넌트 구현

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,5 +34,6 @@ module.exports = {
     '@typescript-eslint/no-use-before-define': ['error'],
     '@next/next/no-img-element': 'off',
     'import/no-extraneous-dependencies': 'off',
+    'react/button-has-type': 'off',
   },
 };

--- a/.stylelintrc.js
+++ b/.stylelintrc.js
@@ -9,5 +9,6 @@ module.exports = {
   rules: {
     'scss/operator-no-unspaced': null,
     'value-keyword-case': null,
+    'scss/operator-no-newline-after': null,
   },
 };

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
+/// <reference types="@emotion/react/types/css-prop" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@stylelint/postcss-css-in-js": "^0.37.2",
     "@types/node": "16.11.9",
     "@types/react": "17.0.36",
+    "@types/react-dom": "^17.0.11",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
     "autoprefixer": "^10.4.0",

--- a/src/components/atoms/Modal.tsx
+++ b/src/components/atoms/Modal.tsx
@@ -1,0 +1,88 @@
+import React, { useMemo, useEffect, ReactNode } from 'react';
+import styled from '@emotion/styled';
+import { createPortal } from 'react-dom';
+import useClickAway from '@hooks/useClickAway';
+import { css } from '@emotion/react';
+
+const BackgroundDim = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 1000;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgb(0 0 0 / 50%);
+`;
+
+const ModalContainer = styled.div`
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: ${({ padding }) =>
+    typeof padding === 'string' ? padding : `${padding}px`};
+  background-color: white;
+  border-radius: 20px;
+  box-shadow: 0 3px 6px rgb(0 0 0 / 20%);
+  transform: translate(-50%, -50%);
+  ${({ width, height }: Partial<ModalProps>) => css`
+    width: ${typeof width === 'string' ? width : `${width}px`};
+    height: ${typeof height === 'string' ? height : `${height}px`};
+  `}
+`;
+
+export interface ModalProps {
+  modalType: 'default' | 'warning';
+  children?: ReactNode;
+  width: number | string;
+  height: number | string;
+  padding: number | string;
+  visible: boolean;
+  clickAway?: boolean;
+  onClose: () => void;
+}
+
+const Modal = ({
+  children,
+  width = 500,
+  height = 500,
+  visible = false,
+  padding = 0,
+  clickAway = false,
+  onClose,
+  ...props
+}: ModalProps) => {
+  const ref = useClickAway(() => {
+    if (onClose && clickAway) {
+      onClose();
+    }
+  });
+
+  const el = useMemo(() => document.createElement('div'), []);
+  useEffect(() => {
+    document.body.appendChild(el);
+    return () => {
+      document.body.removeChild(el);
+    };
+  }, [el]);
+
+  return createPortal(
+    <BackgroundDim style={{ display: visible ? 'block' : 'none' }}>
+      <ModalContainer
+        width={width}
+        height={height}
+        padding={padding}
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </ModalContainer>
+    </BackgroundDim>,
+    el
+  );
+};
+
+export default Modal;

--- a/src/components/domains/ModalButtons.tsx
+++ b/src/components/domains/ModalButtons.tsx
@@ -1,0 +1,74 @@
+import styled from '@emotion/styled';
+import React from 'react';
+import styles from '@styles/index';
+import { css } from '@emotion/react';
+
+export interface ButtonProps {
+  isConfirm?: boolean;
+  modalType: string;
+  onClick: () => void;
+}
+
+export interface ModalButtonsProps extends Partial<ButtonProps> {
+  width: string | number;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+const Button: React.FC<ButtonProps> = styled.button`
+  width: 80px;
+  height: 32px;
+  margin: 0 16px;
+  font-size: ${styles.fontSize.small};
+  font-weight: 700;
+  background: transparent;
+  border: 0;
+  border-radius: 16px;
+  ${({ modalType }: ButtonProps) => css`
+    color: ${modalType === 'default'
+      ? styles.colors.point
+      : styles.colors.warning};
+    border: 2px solid
+      ${modalType === 'default' ? styles.colors.point : styles.colors.warning};
+  `}
+  ${({ modalType, isConfirm }: ButtonProps) =>
+    isConfirm &&
+    css`
+      color: ${modalType === 'default'
+        ? styles.colors.point
+        : styles.colors.background};
+      background: ${modalType === 'default'
+        ? styles.colors.point
+        : styles.colors.warning};
+    `};
+`;
+
+const StyledModalButtons = styled.div`
+  position: absolute;
+  bottom: 30px;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  margin: 0 auto;
+`;
+
+const ModalButtons = ({
+  modalType = 'default',
+  onClose,
+  onConfirm,
+}: ModalButtonsProps) => {
+  return (
+    <StyledModalButtons>
+      {onConfirm && (
+        <Button modalType={modalType} onClick={onConfirm} isConfirm>
+          예
+        </Button>
+      )}
+      <Button modalType={modalType} onClick={onClose}>
+        아니오
+      </Button>
+    </StyledModalButtons>
+  );
+};
+
+export default ModalButtons;

--- a/src/hooks/useClickAway.ts
+++ b/src/hooks/useClickAway.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react';
+
+const events = ['mousedown', 'touchstart'];
+
+const useClickAway = (handler: Function) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const savedHandler = useRef<Function>(handler);
+
+  useEffect(() => {
+    savedHandler.current = handler; // 핸들러 함수가 변하더라도 다시 지우고 이벤트를 추가시키지 않도록 함.
+  }, [handler]);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const handleEvent = (e: any) => {
+      if (!element.contains(e.target)) {
+        savedHandler.current(e);
+      }
+    };
+
+    for (const eventName of events) {
+      document.addEventListener(eventName, handleEvent);
+    }
+
+    return () => {
+      for (const eventName of events) {
+        document.removeEventListener(eventName, handleEvent);
+      }
+    };
+  }, [ref]);
+
+  return ref;
+};
+
+export default useClickAway;

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+import Modal, { ModalProps } from '@components/atoms/Modal';
+import ModalButtons from '@components/domains/ModalButtons';
+import Text from '@components/atoms/Text';
+import styles from '@styles/index';
+import styled from '@emotion/styled';
+
+export default {
+  title: 'Component/Modal',
+  component: Modal,
+  argTypes: {
+    width: {
+      name: 'width',
+      defaultValue: 280,
+      control: { type: 'range', min: 40, max: 600 },
+    },
+    height: {
+      name: 'height',
+      defaultValue: 184,
+      control: { type: 'range', min: 40, max: 600 },
+    },
+    padding: {
+      name: 'padding',
+      defaultValue: 16,
+      control: { type: 'range', min: 0, max: 50 },
+    },
+    clickAway: {
+      name: 'clickAway',
+      defaultValue: false,
+      control: { type: 'boolean' },
+    },
+    modalType: {
+      name: 'modalType',
+      defaultValue: 'default',
+      options: ['default', 'warning'],
+      control: { type: 'radio' },
+    },
+  },
+};
+
+const StyledText = styled.div`
+  margin: 20px 0;
+  font-weight: 700;
+`;
+
+export const Default = (args: ModalProps) => {
+  const [visible, setVisible] = useState(false);
+  const onConfirm = () => {};
+  const onClose = (): void => {
+    setVisible(() => false);
+  };
+  return (
+    <>
+      <button onClick={() => setVisible(true)}>Show Modal</button>
+      <Modal {...args} visible={visible} onClose={onClose}>
+        <StyledText>참여하셨나요?</StyledText>
+        <div>
+          <Text
+            size={11}
+            color={styles.colors.title}
+            underline={false}
+            block
+            paragraph
+          >
+            참여를 완료하시면
+          </Text>
+          <Text
+            size={11}
+            color={styles.colors.title}
+            underline={false}
+            block
+            paragraph
+          >
+            다음에는 참여가 불가능합니다.
+          </Text>
+        </div>
+        <ModalButtons
+          modalType="warning"
+          width={192}
+          onConfirm={onConfirm}
+          onClose={onClose}
+        />
+      </Modal>
+    </>
+  );
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,6 @@
       "@apis/*": ["./src/apis/*"],
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "src/hooks/useClickAway.ts", "src/components/atoms/Modal.tsx"],
   "exclude": ["node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2588,6 +2588,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@^17.0.11":
+  version "17.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.11.tgz#e1eadc3c5e86bdb5f7684e00274ae228e7bcc466"
+  integrity sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-syntax-highlighter@11.0.5":
   version "11.0.5"
   resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.5.tgz#0d546261b4021e1f9d85b50401c0a42acb106087"


### PR DESCRIPTION
1. Modal 컴포넌트 구현 (atoms)
2. Modal에서 예 / 아니오에 따른 버튼 구현 (domains)
3. Storybook을 통한 모달 테스트 구현

## `Storybook.Modal.tsx`
![image](https://user-images.githubusercontent.com/78713176/144709945-0f133505-46d9-4489-a4d8-b000d87f37da.png)

## [중요] 추가 사항

### `@types/react-dom`
react-dom의 `createPortal`을 이용하는 데 필요합니다.

### Lint Rules
+ `scss/operator-no-newline-after`
화살표 함수에서 `prettier`로 인해 새로운 라인이 되었을 때, `>`이 마지막에 오는 걸 막는 룰이므로, 해제하였습니다.

+ 'react/button-has-type': 'off'
보통 `type`은 `button`이기 때문에, 이를 계속 타이핑한다는 것은 지나친 생산성 저해가 우려되었습니다. 따라서 해제하였습니다.