### PR TITLE
[TLVB-28] CardContainer 구현

### DIFF
--- a/src/components/atoms/CardContainer.tsx
+++ b/src/components/atoms/CardContainer.tsx
@@ -1,0 +1,72 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import styles from '@styles/index';
+import React from 'react';
+
+export interface CardStyleProps {
+  padding: number | string;
+  width?: number | string;
+  margin?: number | string;
+}
+
+export interface StyledDefaultCardProps extends CardStyleProps {
+  bgColorName: 'yellow' | 'orange' | 'pink' | 'yellowGreen' | 'mint';
+}
+
+export interface CardContainerProps extends CardStyleProps {
+  cardType: 'default' | 'box';
+  bgColorName: 'yellow' | 'orange' | 'pink' | 'yellowGreen' | 'mint';
+}
+
+const StyledDefaultCardContainer = styled('article')<StyledDefaultCardProps>`
+  height: 120px;
+  filter: drop-shadow(0 4px 4px rgb(0 0 0 / 25%));
+  border-radius: 16px;
+  ${({ width, margin, padding, bgColorName }) => css`
+    width: ${typeof width === 'string' ? width : `${width}px`};
+    padding: ${typeof padding === 'string' ? padding : `${padding}px`};
+    margin: ${typeof margin === 'string' ? margin : `${margin}px`};
+    background: ${`linear-gradient(
+      93.41deg,
+      ${styles.cardBackgroundColors[bgColorName]} 14.53%,
+      ${styles.cardBackgroundColors[bgColorName]} 93.07%
+    ) `};
+  `}
+`;
+
+const StyledBoxCardContainer = styled('article')<CardStyleProps>`
+  height: 170px;
+  background: ${styles.colors.background};
+  filter: drop-shadow(0 4px 4px rgb(0 0 0 / 25%));
+  border-radius: 16px;
+  ${({ width, margin, padding }) => css`
+    width: ${width
+      ? typeof width === 'string'
+        ? width
+        : `${width}px`
+      : `calc(50% - ${typeof margin === 'string' ? margin : `${margin}px`}) `};
+    padding: ${typeof padding === 'string' ? padding : `${padding}px`};
+    margin: ${typeof margin === 'string' ? margin : `${margin}px`};
+  `}
+`;
+
+const CardContainer = ({
+  cardType = 'default',
+  width,
+  padding = 0,
+  margin,
+  bgColorName = 'orange',
+}: CardContainerProps) => {
+  return cardType === 'box' ? (
+    <StyledBoxCardContainer margin={margin} padding={padding} width={width} />
+  ) : (
+    <StyledDefaultCardContainer
+      margin={margin}
+      padding={padding}
+      width={width}
+      bgColorName={bgColorName}
+    />
+  );
+};
+
+export default CardContainer;

--- a/src/stories/CardContainer.stories.tsx
+++ b/src/stories/CardContainer.stories.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import CardContainer, {
+  CardContainerProps,
+} from '@components/atoms/CardContainer';
+import styles from '@styles/index';
+
+export default {
+  title: 'Example/CardContainer',
+  component: CardContainer,
+  argTypes: {
+    cardType: {
+      name: 'modalType',
+      defaultValue: 'default',
+      options: ['default', 'box'],
+      control: { type: 'radio' },
+    },
+    width: {
+      name: 'width',
+      defaultValue: 320,
+      control: { type: 'range', min: 200, max: 600 },
+    },
+    padding: {
+      name: 'padding',
+      defaultValue: 0,
+      control: { type: 'range', min: 0, max: 50 },
+    },
+    margin: {
+      name: 'margin',
+      defaultValue: 0,
+      control: { type: 'range', min: 0, max: 50 },
+    },
+    bgColorName: {
+      name: 'bgColorName',
+      defaultValue: 'yellow',
+      options: Object.keys(styles.cardBackgroundColors),
+      control: { type: 'radio' },
+    },
+  },
+};
+
+const Template = (args: CardContainerProps) => <CardContainer {...args} />;
+
+export const Default = Template.bind({});

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -41,4 +41,12 @@ export default {
     md: '(min-width : 768px) and (max-width : 1200px)',
     lg: '(min-width: 1201px)',
   },
+
+  cardBackgroundColors: {
+    yellow: '#F8D498',
+    orange: '#F8BC9B',
+    pink: '#F2A9BB',
+    yellowGreen: '#95EBB9',
+    mint: '#7FE5DA',
+  },
 };


### PR DESCRIPTION
## 구현 사항
- 카드 형태에 따라 담는 형태가 바뀌는 컨테이너를 구현하였습니다 - atoms
![image](https://user-images.githubusercontent.com/78713176/144733309-796f084f-ed14-4f49-8e7a-d3005113225c.png)
![image](https://user-images.githubusercontent.com/78713176/144733324-94361af0-5a80-4ab9-8b54-5e0d9ecc2d57.png)

## 주의 사항
- cardType은 1. `default`와 `box` 형태가 있습니다.
- box의 경우 2개로 `flex-wrap`되는 형태이므로 `width`가 정해져있지 않다면 `margin`을 주어 `calc`에서 계산이 가능하도록 설정하였습니다.
- filter의 경우 기본적으로 `border` 혹은 `background`가 있으므로 `box`의 `bgColor`을 `styles.colors.background`로 명시하였습니다.

## 참고 소스
현재 지라에 상세한 코드에 대한 설명을 올렸으니 참고 바랍니다.
[지라 PR url](https://6th-dev-course.atlassian.net/jira/software/projects/TLVB/boards/1?selectedIssue=TLVB-28)