### PR TITLE
[TLVB-78] MainContainer 구현

### DIFF
--- a/src/components/atoms/MainContainer.tsx
+++ b/src/components/atoms/MainContainer.tsx
@@ -1,0 +1,43 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import styles from '@styles/index';
+import React, { ReactNode } from 'react';
+
+interface StyledMainContainerProps {
+  paddingWidth?: number | string;
+  paddingHeight?: number | string;
+}
+export interface MainContainerProps extends StyledMainContainerProps {
+  children: ReactNode;
+}
+const StyledMainContainer: React.FC<MainContainerProps> = styled.main`
+  width: 375px;
+  height: 100vh;
+  @media ${styles.media.mobile} {
+    width: 100%;
+  }
+
+  ${({ paddingWidth, paddingHeight }: StyledMainContainerProps) => css`
+    padding: ${typeof paddingHeight === 'string'
+        ? paddingHeight
+        : `${paddingHeight}px`}
+      ${typeof paddingWidth === 'string' ? paddingWidth : `${paddingWidth}px`};
+  `}
+`;
+
+const MainContainer = ({
+  children,
+  paddingWidth = 24,
+  paddingHeight = 0,
+}: MainContainerProps) => {
+  return (
+    <StyledMainContainer
+      paddingWidth={paddingWidth}
+      paddingHeight={paddingHeight}
+    >
+      {children}
+    </StyledMainContainer>
+  );
+};
+
+export default MainContainer;

--- a/src/stories/MainContainer.stories.tsx
+++ b/src/stories/MainContainer.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import MainContainer from '@components/atoms/MainContainer';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+export default {
+  title: 'Component/atoms/MainContainer',
+  component: MainContainer,
+  argTypes: {
+    paddingWidth: {
+      name: 'paddingWidth',
+      defaultValue: 24,
+      control: { type: 'range', min: 0, max: 100 },
+    },
+    paddingHeight: {
+      name: 'paddingHeight',
+      defaultValue: 0,
+      control: { type: 'range', min: 0, max: 50 },
+    },
+  },
+} as ComponentMeta<typeof MainContainer>;
+
+const Template = (args: ComponentStory<typeof MainContainer>) => (
+  <MainContainer {...args}>MainContainer!</MainContainer>
+);
+
+export const Default = Template.bind({});

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -38,6 +38,7 @@ export default {
   },
 
   media: {
+    mobile: '(max-width: 480px)',
     sm: '(max-width: 767px)',
     md: '(min-width : 768px) and (max-width : 1200px)',
     lg: '(min-width: 1201px)',


### PR DESCRIPTION
## PR 설명

화면 내의 실제 메인 콘텐츠를 보여줄 `MainContainer`을 생성합니다.

## PR Point

1. `styles/index.ts`에서 기존과 달리 `mobile`을 추가.
2. `mobile`의 경우 실제 `mobile`에서의 최대 크기인 `480px`을 기준으로 삼음.
3. 따라서 모바일이 아니라면 현재 와이어프레임 기준인 `375px`을 기준으로 보여주도록 설정

## 시연 영상
실제로 개발자 도구에서 `width`가 작아지면, `width: 100%`로 변화하는 것을 확인 가능합니다.
![MainContainer](https://user-images.githubusercontent.com/78713176/145517254-aff7542c-39d0-4f05-ad30-793aa59b9dd2.gif)
