### PR TITLE
[TLVB-81] Axios 공통 헤더 설정 및 기타 응답값 추가 설정

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,7 @@ module.exports = {
     '@next/next/google-font-display': 'off',
     '@next/next/no-page-custom-font': 'off',
     '@typescript-eslint/no-unused-vars': [2, { args: 'none' }],
+    'no-param-reassign': 'off',
   },
   globals: {
     React: true,

--- a/src/axios/event/getEvent.ts
+++ b/src/axios/event/getEvent.ts
@@ -1,0 +1,18 @@
+import request from '@axios/index';
+import { Event } from '@contexts/event/types';
+
+interface GetEventParamTypes {
+  eventId: string | undefined | string[];
+}
+
+const getEvent = async ({ eventId }: GetEventParamTypes) => {
+  /* eslint-disable no-console */
+  if (typeof eventId === 'object') {
+    console.warn('nowParam is array ', eventId);
+  }
+
+  const res: Event = await request.get('/e49e47f9-739a-4014-8395-efa1f810aebb');
+  return res;
+};
+
+export default getEvent;

--- a/src/axios/event/getEventList.ts
+++ b/src/axios/event/getEventList.ts
@@ -1,8 +1,9 @@
-import { request } from '@axios/index';
+import request from '@axios/index';
 
 const getEventList = async () => {
   const res = await request.get('/v3/96effad6-e14a-4094-9ab4-d7932bf1bc33');
-  return res;
+
+  return res.data;
 };
 
 export default getEventList;

--- a/src/axios/index.ts
+++ b/src/axios/index.ts
@@ -1,44 +1,66 @@
-import axios, {
-  AxiosError,
-  AxiosInstance,
-  AxiosRequestConfig,
-  AxiosResponse,
-} from 'axios';
-
-interface optionsType {
-  [option: string]: any;
-}
+import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 
 // TODO: 추후 백엔드와 협의 후 설정사항이 있다면 request에 옵션을 넣어 설정하기로 한다.
 /* eslint-disable prefer-destructuring */
 const API_END_POINT = 'https://run.mocky.io'; // Mock Test API BASE URL
+const USER_AUTH_TOKEN_NAME = 'X-AUTH-TOKEN';
 
-const configInterceptorCallback = (config: AxiosRequestConfig) => config;
-const errorCallback = (error: AxiosError) => Promise.reject(error.response);
-const setInterceptors = (instance: AxiosInstance) => {
-  instance.interceptors.request.use(configInterceptorCallback, errorCallback);
+const requestConfigCallback = (
+  authConfig: any
+): AxiosRequestConfig | Promise<AxiosRequestConfig<any>> => {
+  const X_USER_TOKEN = window
+    ? ''
+    : JSON.parse(localStorage.getItem(USER_AUTH_TOKEN_NAME) || '');
 
-  instance.interceptors.response.use(
-    (response: AxiosResponse) => {
-      return response.data;
+  if (X_USER_TOKEN) {
+    authConfig.headers[USER_AUTH_TOKEN_NAME] = `Bearer ${X_USER_TOKEN}`;
+  }
+
+  return authConfig;
+};
+const rejectRequestConfigCallback = (error: any) =>
+  Promise.reject(error.response);
+
+const successResponseCallback = (
+  res: any
+): AxiosResponse | Promise<AxiosResponse<any>> => {
+  return {
+    ...res,
+    error: {
+      code: null,
+      message: null,
     },
-    (error) => {
-      return Promise.reject(error.response);
-    }
+  };
+};
+const errorResponseCallback = (res: any) => {
+  return {
+    ...res,
+    error: {
+      code: res?.response?.status || 500,
+      message: '', // TODO: 백엔드 쪽에서 메시지를 전달해줄 것인지 협의한다.
+    },
+  };
+};
+
+const setInterceptors = (instance: AxiosInstance) => {
+  instance.interceptors.request.use(
+    requestConfigCallback,
+    rejectRequestConfigCallback
+  );
+  instance.interceptors.response.use(
+    successResponseCallback,
+    errorResponseCallback
   );
   return instance;
 };
 
-const createInstance = (options: optionsType) => {
+const createInstance = () => {
   const instance: AxiosInstance = axios.create({
-    ...options,
+    baseURL: API_END_POINT,
   });
   return setInterceptors(instance);
 };
 
-const request = createInstance({
-  baseURL: API_END_POINT,
-  timeout: 5000,
-});
+const request = createInstance();
 
 export { request };

--- a/src/axios/index.ts
+++ b/src/axios/index.ts
@@ -1,4 +1,9 @@
-import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
+import axios, {
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosResponse,
+  AxiosResponseHeaders,
+} from 'axios';
 
 // TODO: 추후 백엔드와 협의 후 설정사항이 있다면 request에 옵션을 넣어 설정하기로 한다.
 /* eslint-disable prefer-destructuring */
@@ -21,13 +26,20 @@ const requestConfigCallback = (
 const rejectRequestConfigCallback = (error: any) =>
   Promise.reject(error.response);
 
-const successResponseCallback = (
-  res: any
-): AxiosResponse | Promise<AxiosResponse<any>> => {
+interface ResType {
+  data: keyof AxiosResponse;
+  headers: AxiosResponseHeaders;
+  error: {
+    code: number | null;
+    message: string | null;
+  };
+}
+const successResponseCallback = (res: AxiosResponse): ResType => {
   return {
-    ...res,
+    data: res.data,
+    headers: res.headers,
     error: {
-      code: null,
+      code: res.status,
       message: null,
     },
   };
@@ -63,4 +75,4 @@ const createInstance = () => {
 
 const request = createInstance();
 
-export { request };
+export default request;


### PR DESCRIPTION
## PR 설명
Axios로 일관된 요청 값과 응답 값을 받을 수 있도록 인터셉터를 설정해주었습니다.

## 구현 사항
1. SSR에서의 빌드 오류를 예방하고자 `window` 객체가 없을 경우에는 로컬스토리지에 있는 값을 체크하지 않고, 헤더를 포함하지 않도록 설정
2. 결과 값의 경우 `error`의 값이 null, 아니라면 `error`의 값에 `code`가 있도록 설정

## 미구현 사항
1. 실제 테스트 미적용 (API 구체화 및 UI 로직을 그리면서 적용하며 수정할 예정)
2. `error message`의 경우 프론트엔드 측에서 처리할지, 백엔드에서 처리할지 의논 X -> 향후 회의 후 변경할 예정