### PR TITLE
[TLVB-94] Event 상세 보기 페이지 레이아웃 구현

### DIFF
--- a/fixtures/event.ts
+++ b/fixtures/event.ts
@@ -11,7 +11,13 @@ const event = {
   isFavorite: true,
   pictures: [
     {
-      url: '1234.png',
+      url: 'https://picsum.photos/200',
+    },
+    {
+      url: 'https://picsum.photos/200',
+    },
+    {
+      url: 'https://picsum.photos/200',
     },
   ],
   isParticipated: true,

--- a/fixtures/reviews.ts
+++ b/fixtures/reviews.ts
@@ -2,7 +2,7 @@ const reviews = [
   {
     description:
       '사장님이 추천해주셔서 감자튀김도 먹었습니다! 정말 맛있었고, 소스도 훌륭했던 것 같아요~',
-    pictureUrl: '1234.png',
+    pictureUrl: 'https://picsum.photos/200',
     author: '카즈마',
     createAt: '20211201',
   },

--- a/src/components/atoms/HeaderText.tsx
+++ b/src/components/atoms/HeaderText.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import React, { ReactNode } from 'react';
 
@@ -6,9 +7,10 @@ export type LevelTypes = 1 | 2 | 3 | 4;
 export interface HeaderTextProps {
   children: ReactNode;
   level: LevelTypes;
+  marginBottom?: number | string;
   [prop: string]: any;
 }
-const StyledHeaderTag: React.FC<HeaderTextProps> = styled.div`
+const StyledHeaderTag = styled.div<HeaderTextProps>`
   font-size: ${({ level }: { level: LevelTypes }) => {
     const fontSizes = {
       1: '24px',
@@ -18,17 +20,30 @@ const StyledHeaderTag: React.FC<HeaderTextProps> = styled.div`
     };
     return fontSizes[level];
   }};
+  ${({ marginBottom }) =>
+    marginBottom &&
+    css`
+      margin-bottom: ${typeof marginBottom === 'string'
+        ? marginBottom
+        : `${marginBottom}px`};
+    `}
   font-weight: 700;
   word-break: keep-all;
 `;
 
-const HeaderText = ({ children, level = 1, ...props }: HeaderTextProps) => {
+const HeaderText = ({
+  children,
+  level = 1,
+  marginBottom = 0,
+  ...props
+}: HeaderTextProps) => {
   const HeaderTag = `h${level}` as keyof JSX.IntrinsicElements;
   return (
     <StyledHeaderTag
       as={HeaderTag}
       level={level}
       HeaderTag={HeaderTag}
+      marginBottom={marginBottom}
       {...props}
     >
       {children}

--- a/src/components/atoms/HeaderText.tsx
+++ b/src/components/atoms/HeaderText.tsx
@@ -11,6 +11,8 @@ export interface HeaderTextProps {
   [prop: string]: any;
 }
 const StyledHeaderTag = styled.div<HeaderTextProps>`
+  font-weight: 700;
+  word-break: keep-all;
   font-size: ${({ level }: { level: LevelTypes }) => {
     const fontSizes = {
       1: '24px',
@@ -27,8 +29,6 @@ const StyledHeaderTag = styled.div<HeaderTextProps>`
         ? marginBottom
         : `${marginBottom}px`};
     `}
-  font-weight: 700;
-  word-break: keep-all;
 `;
 
 const HeaderText = ({

--- a/src/components/atoms/HeaderText.tsx
+++ b/src/components/atoms/HeaderText.tsx
@@ -19,12 +19,18 @@ const StyledHeaderTag: React.FC<HeaderTextProps> = styled.div`
     return fontSizes[level];
   }};
   font-weight: 700;
+  word-break: keep-all;
 `;
 
-const HeaderText = ({ children, level = 1 }: HeaderTextProps) => {
+const HeaderText = ({ children, level = 1, ...props }: HeaderTextProps) => {
   const HeaderTag = `h${level}` as keyof JSX.IntrinsicElements;
   return (
-    <StyledHeaderTag as={HeaderTag} level={level} HeaderTag={HeaderTag}>
+    <StyledHeaderTag
+      as={HeaderTag}
+      level={level}
+      HeaderTag={HeaderTag}
+      {...props}
+    >
       {children}
     </StyledHeaderTag>
   );

--- a/src/components/atoms/HeaderText.tsx
+++ b/src/components/atoms/HeaderText.tsx
@@ -11,8 +11,6 @@ export interface HeaderTextProps {
   [prop: string]: any;
 }
 const StyledHeaderTag = styled.div<HeaderTextProps>`
-  font-weight: 700;
-  word-break: keep-all;
   font-size: ${({ level }: { level: LevelTypes }) => {
     const fontSizes = {
       1: '24px',
@@ -22,6 +20,8 @@ const StyledHeaderTag = styled.div<HeaderTextProps>`
     };
     return fontSizes[level];
   }};
+  font-weight: 700;
+  word-break: keep-all;
   ${({ marginBottom }) =>
     marginBottom &&
     css`

--- a/src/components/domains/CategoryList.tsx
+++ b/src/components/domains/CategoryList.tsx
@@ -17,7 +17,7 @@ export interface CategoryListProps extends StyledCategoryListProps {
   headerLevel: LevelTypes;
   headerMarginBottom: string | number;
   categoryName: string;
-  onClick: () => void;
+  onClick?: () => void;
   flexType: 'default' | 'column' | 'none';
   [prop: string]: any;
 }

--- a/src/components/domains/EventDetail/EventDescriptions.tsx
+++ b/src/components/domains/EventDetail/EventDescriptions.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import React from 'react';
 
 const StyledEventDescriptions = styled.article`
-  margin-bottom: 10px;
+  margin-bottom: 20px;
 `;
 
 const DescriptionBox = styled.div`

--- a/src/components/domains/EventDetail/EventDescriptions.tsx
+++ b/src/components/domains/EventDetail/EventDescriptions.tsx
@@ -1,0 +1,57 @@
+import { Button, HeaderText, Text } from '@components/atoms';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import React from 'react';
+
+const StyledEventDescriptions = styled.article`
+  margin-bottom: 10px;
+`;
+
+const DescriptionBox = styled.div`
+  /* display: inline-flex; */
+`;
+const MoreDescriptionButtonCSS = css`
+  margin-left: 10px;
+  text-anchor: end;
+`;
+
+interface EventDescriptionsProps extends Partial<Event> {
+  eventDescription: string;
+  [prop: string]: any;
+}
+
+const EventDescriptions = ({ eventDescription }: EventDescriptionsProps) => {
+  return (
+    <StyledEventDescriptions>
+      <HeaderText level={2} marginBottom={16}>
+        소개
+      </HeaderText>
+      <DescriptionBox>
+        {eventDescription?.length > 20 ? (
+          <>
+            <Text size="small" width={40} height="auto">
+              {`${eventDescription.slice(0, 20)}...`}
+            </Text>
+            <Button
+              display="inline-box"
+              fontSize={11}
+              reversal
+              width="auto"
+              height="auto"
+              padding={0}
+              css={MoreDescriptionButtonCSS}
+            >
+              더보기
+            </Button>
+          </>
+        ) : (
+          <Text size="small" width={40} height="auto">
+            {eventDescription || '이벤트 소개가 없어요! 😅'}
+          </Text>
+        )}
+      </DescriptionBox>
+    </StyledEventDescriptions>
+  );
+};
+
+export default EventDescriptions;

--- a/src/components/domains/EventDetail/EventDetailHeader.tsx
+++ b/src/components/domains/EventDetail/EventDetailHeader.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import React from 'react';
 
-const EventDetailHeaderCSS = css`
+const StyledEventDetailHeader = styled.header`
   margin: 20px 0;
 `;
 const LikeButtonCSS = css`
@@ -42,7 +42,7 @@ const EventDetailHeader = ({
   isParticipated,
 }: EventDetailHeaderProps) => {
   return (
-    <header css={EventDetailHeaderCSS}>
+    <StyledEventDetailHeader>
       <LikeExpiredAtBox>
         {isLike && (
           <Button
@@ -84,7 +84,7 @@ const EventDetailHeader = ({
       <Button buttonType="primary">
         {isParticipated ? '참여 완료' : '참여 하기'}
       </Button>
-    </header>
+    </StyledEventDetailHeader>
   );
 };
 

--- a/src/components/domains/EventDetail/EventDetailHeader.tsx
+++ b/src/components/domains/EventDetail/EventDetailHeader.tsx
@@ -1,0 +1,91 @@
+import { Button, HeaderText, Text } from '@components/atoms';
+import { Event } from '@contexts/event/types';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import React from 'react';
+
+const EventDetailHeaderCSS = css`
+  margin: 24px 0;
+`;
+const LikeButtonCSS = css`
+  margin-right: 10px;
+`;
+const FavoriteButtonCSS = css`
+  margin-left: 10px;
+`;
+
+const LikeExpiredAtBox = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const MarketInfo = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 24px;
+`;
+
+const HeaderTextCSS = css`
+  margin: 10px 0;
+`;
+
+interface EventDetailHeaderProps extends Partial<Event> {
+  [index: string]: any;
+}
+
+const EventDetailHeader = ({
+  expiredAt,
+  marketName,
+  name,
+  isLike,
+  isFavorite,
+  isParticipated,
+}: EventDetailHeaderProps) => {
+  return (
+    <header css={EventDetailHeaderCSS}>
+      <LikeExpiredAtBox>
+        {isLike && (
+          <Button
+            buttonType="primary"
+            reversal
+            borderRadius={8}
+            width={70}
+            height={24}
+            fontSize={11}
+            border
+            css={LikeButtonCSS}
+          >
+            +좋아요
+          </Button>
+        )}
+        <Text size="small">{`~${expiredAt} 까지`}</Text>
+      </LikeExpiredAtBox>
+      <HeaderText level={1} css={HeaderTextCSS}>
+        {name}
+      </HeaderText>
+      <MarketInfo>
+        <Text size="small">{marketName || ''}</Text>
+        {isFavorite && (
+          <Button
+            buttonType="primary"
+            reversal
+            borderRadius={8}
+            width={76}
+            height={24}
+            fontSize={11}
+            padding={0}
+            border
+            css={FavoriteButtonCSS}
+          >
+            ⭐ 즐겨찾기
+          </Button>
+        )}
+      </MarketInfo>
+      <Button buttonType="primary">
+        {isParticipated ? '참여 완료' : '참여 하기'}
+      </Button>
+    </header>
+  );
+};
+
+export default EventDetailHeader;

--- a/src/components/domains/EventDetail/EventDetailHeader.tsx
+++ b/src/components/domains/EventDetail/EventDetailHeader.tsx
@@ -5,7 +5,7 @@ import styled from '@emotion/styled';
 import React from 'react';
 
 const EventDetailHeaderCSS = css`
-  margin: 24px 0;
+  margin: 20px 0;
 `;
 const LikeButtonCSS = css`
   margin-right: 10px;
@@ -22,7 +22,7 @@ const LikeExpiredAtBox = styled.div`
 const MarketInfo = styled.div`
   display: flex;
   align-items: center;
-  margin-bottom: 24px;
+  margin-bottom: 20px;
 `;
 
 const HeaderTextCSS = css`

--- a/src/components/domains/EventDetail/EventReview.tsx
+++ b/src/components/domains/EventDetail/EventReview.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { CategoryList, ReviewCard } from '@components/domains';
+import reviews from 'fixtures/reviews';
+
+const EventReview = () => {
+  const review = reviews[0];
+  return (
+    <CategoryList
+      flexType="column"
+      width="100%"
+      padding={0}
+      margin={0}
+      categoryName="이벤트 리뷰"
+      headerMarginBottom={16}
+      headerLevel={2}
+    >
+      <ReviewCard
+        cardType="default"
+        bgColorName="default"
+        padding={10}
+        margin="10px 0"
+        reviewData={review}
+      />
+    </CategoryList>
+  );
+};
+
+export default EventReview;

--- a/src/components/domains/EventDetail/MarketDescriptions.tsx
+++ b/src/components/domains/EventDetail/MarketDescriptions.tsx
@@ -18,11 +18,11 @@ const MarketImageBox = styled.section`
   margin-top: 10px;
 
   div {
-    &:first-child {
+    &:first-of-type {
       margin-left: 0;
     }
 
-    &:last-child {
+    &:last-of-type {
       margin-right: 0;
     }
   }
@@ -51,8 +51,9 @@ const MarketDescriptions = ({
         {marketDescription || '등록된 가게 소개가 없어요!'}
       </Text>
       <MarketImageBox>
-        {pictures.map(({ url }) => (
+        {pictures.map(({ url }, idx) => (
           <ImageContainer
+            key={`${url + idx}`}
             src={url}
             alt="가게 사진"
             width={96}

--- a/src/components/domains/EventDetail/MarketDescriptions.tsx
+++ b/src/components/domains/EventDetail/MarketDescriptions.tsx
@@ -9,7 +9,7 @@ const DescriptionCSS = css`
 
 const StyledMarketDescriptions = styled.article`
   margin-top: 4px;
-  margin-bottom: 24px;
+  margin-bottom: 20px;
 `;
 
 const MarketImageBox = styled.section`

--- a/src/components/domains/EventDetail/MarketDescriptions.tsx
+++ b/src/components/domains/EventDetail/MarketDescriptions.tsx
@@ -1,0 +1,68 @@
+import { HeaderText, ImageContainer, Text } from '@components/atoms';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import React from 'react';
+
+const DescriptionCSS = css`
+  min-height: 32px;
+`;
+
+const StyledMarketDescriptions = styled.article`
+  margin-top: 4px;
+  margin-bottom: 24px;
+`;
+
+const MarketImageBox = styled.section`
+  display: flex;
+  height: auto;
+  margin-top: 10px;
+
+  div {
+    &:first-child {
+      margin-left: 0;
+    }
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+`;
+
+interface PictureType {
+  url: string;
+}
+
+interface MarketDescriptionsProps extends Partial<Event> {
+  marketDescription: string | undefined;
+  pictures: Array<PictureType> | [];
+  [prop: string]: any;
+}
+
+const MarketDescriptions = ({
+  marketDescription,
+  pictures,
+}: MarketDescriptionsProps) => {
+  return (
+    <StyledMarketDescriptions>
+      <HeaderText level={2} marginBottom={16}>
+        내용
+      </HeaderText>
+      <Text size="small" paragraph css={DescriptionCSS}>
+        {marketDescription || '등록된 가게 소개가 없어요!'}
+      </Text>
+      <MarketImageBox>
+        {pictures.map(({ url }) => (
+          <ImageContainer
+            src={url}
+            alt="가게 사진"
+            width={96}
+            height={96}
+            margin="0 8px"
+          />
+        ))}
+      </MarketImageBox>
+    </StyledMarketDescriptions>
+  );
+};
+
+export default MarketDescriptions;

--- a/src/components/domains/EventDetail/index.tsx
+++ b/src/components/domains/EventDetail/index.tsx
@@ -1,4 +1,6 @@
 export { default as EventDescriptions } from './EventDescriptions';
 export { default as EventDetailHeader } from './EventDetailHeader';
-export { default as EventReview } from './EventReview';
 export { default as MarketDescriptions } from './MarketDescriptions';
+
+/* eslint-disable import/no-cycle */
+export { default as EventReview } from './EventReview';

--- a/src/components/domains/EventDetail/index.tsx
+++ b/src/components/domains/EventDetail/index.tsx
@@ -1,0 +1,4 @@
+export { default as EventDescriptions } from './EventDescriptions';
+export { default as EventDetailHeader } from './EventDetailHeader';
+export { default as EventReview } from './EventReview';
+export { default as MarketDescriptions } from './MarketDescriptions';

--- a/src/components/domains/ReviewCard.tsx
+++ b/src/components/domains/ReviewCard.tsx
@@ -27,7 +27,7 @@ const ImageContainerCSS = css`
 `;
 
 interface reviewDataTypes {
-  marketName: string;
+  marketName?: string;
   pictureUrl: string | undefined;
   description: string;
 }
@@ -64,7 +64,7 @@ const ReviewCard = ({
             2021.12.09
           </Text>
           <Text block size="micro">
-            {reviewData.marketName}
+            {reviewData.marketName || ''}
           </Text>
         </>
       ) : (

--- a/src/components/domains/index.ts
+++ b/src/components/domains/index.ts
@@ -5,3 +5,5 @@ export { default as LoginForm } from './LoginForm';
 export { default as ModalButtons } from './ModalButtons';
 export { default as RegisterForm } from './RegisterForm';
 export { default as SortButtons } from './SortButtons';
+export { default as ReviewCard } from './ReviewCard';
+export * from './EventDetail/index';

--- a/src/pages/event/[eventId]/index.tsx
+++ b/src/pages/event/[eventId]/index.tsx
@@ -1,19 +1,36 @@
-import getEvent from '@axios/event/getEvent';
-import { useRouter } from 'next/dist/client/router';
-import React, { useEffect, useState } from 'react';
+import { MainContainer } from '@components/atoms';
+import { Header } from '@components/domains';
+import EventDetailHeader from '@components/domains/EventDetail/EventDetailHeader';
+import { Event } from '@contexts/event/types';
+import eventData from 'fixtures/event';
+import React from 'react';
 
 const EventDetailPage = () => {
-  const router = useRouter();
-  const [name, setName] = useState<string>('');
-  const { eventId } = router.query;
-  useEffect(() => {
-    async function getName() {
-      const res = await getEvent({ eventId });
-      setName(() => res.name);
-    }
-    getName();
-  }, [eventId]);
-  return <div>{name} 이벤트 상세 페이지</div>;
+  const {
+    eventId,
+    name,
+    expiredAt,
+    marketName,
+    marketDescription,
+    eventDescription,
+    isLike,
+    isFavorite,
+    pictures,
+    isParticipated,
+  } = eventData as Event;
+  return (
+    <MainContainer paddingWidth={24}>
+      <Header />
+      <EventDetailHeader
+        expiredAt={expiredAt}
+        marketName={marketName}
+        name={name}
+        isLike={isLike}
+        isFavorite={isFavorite}
+        isParticipated={isParticipated}
+      />
+    </MainContainer>
+  );
 };
 
 export default EventDetailPage;

--- a/src/pages/event/[eventId]/index.tsx
+++ b/src/pages/event/[eventId]/index.tsx
@@ -1,5 +1,5 @@
 import { MainContainer } from '@components/atoms';
-import { Header } from '@components/domains';
+import { EventReview, Header } from '@components/domains';
 import EventDescriptions from '@components/domains/EventDetail/EventDescriptions';
 import EventDetailHeader from '@components/domains/EventDetail/EventDetailHeader';
 import MarketDescriptions from '@components/domains/EventDetail/MarketDescriptions';
@@ -35,6 +35,7 @@ const EventDetailPage = () => {
         pictures={pictures}
       />
       <EventDescriptions eventDescription={eventDescription} />
+      <EventReview />
     </MainContainer>
   );
 };

--- a/src/pages/event/[eventId]/index.tsx
+++ b/src/pages/event/[eventId]/index.tsx
@@ -1,13 +1,14 @@
 import { MainContainer } from '@components/atoms';
 import { Header } from '@components/domains';
+import EventDescriptions from '@components/domains/EventDetail/EventDescriptions';
 import EventDetailHeader from '@components/domains/EventDetail/EventDetailHeader';
+import MarketDescriptions from '@components/domains/EventDetail/MarketDescriptions';
 import { Event } from '@contexts/event/types';
 import eventData from 'fixtures/event';
 import React from 'react';
 
 const EventDetailPage = () => {
   const {
-    eventId,
     name,
     expiredAt,
     marketName,
@@ -29,6 +30,11 @@ const EventDetailPage = () => {
         isFavorite={isFavorite}
         isParticipated={isParticipated}
       />
+      <MarketDescriptions
+        marketDescription={marketDescription}
+        pictures={pictures}
+      />
+      <EventDescriptions eventDescription={eventDescription} />
     </MainContainer>
   );
 };

--- a/src/stories/atoms/HeaderText.stories.tsx
+++ b/src/stories/atoms/HeaderText.stories.tsx
@@ -21,9 +21,23 @@ export default {
         type: 'text',
       },
     },
+    marginBottom: {
+      name: 'marginBottom',
+      defaultValue: 0,
+      control: {
+        type: 'range',
+        min: 0,
+        max: 50,
+      },
+    },
   },
 };
 
-const Template = (args: HeaderTextProps) => <HeaderText {...args} />;
+const Template = (args: HeaderTextProps) => (
+  <div>
+    <HeaderText {...args} />
+    <span>Content!</span>
+  </div>
+);
 
 export const Default = Template.bind({});


### PR DESCRIPTION
## PR 설명
본격적으로 유저 시나리오에 따른 로직 개발을 착수하기에 앞서 이벤트 상세 보기 페이지의 레이아웃을 구현합니다.

## 구현
페이지의 템플릿 단위로 차례대로 구현을 완료하였습니다.
- EventDetailHeader 구현
- MarketDescriptions 구현
- EventReview 구현
- `fixtures`를 통한 간단한 테스트 데이터 적용

## 미구현 사항
- 클릭 등의 상세 UI 로직에 대해서는 처리하지 않았습니다.
- 실제 라우팅 기능이 구현되지 않았습니다. (테스트 API & data의 한계)

## 시연 영상
![EventDetailPage](https://user-images.githubusercontent.com/78713176/145697612-9b09236c-2ae2-427e-8d70-1576053c3c1d.gif)