### PR TITLE
[TLVB-95] EventReviewPage 레이아웃 구현

### DIFF
--- a/fixtures/event.ts
+++ b/fixtures/event.ts
@@ -14,10 +14,10 @@ const event = {
       url: 'https://picsum.photos/200',
     },
     {
-      url: 'https://picsum.photos/200',
+      url: 'https://picsum.photos/201',
     },
     {
-      url: 'https://picsum.photos/200',
+      url: 'https://picsum.photos/202',
     },
   ],
   isParticipated: true,

--- a/fixtures/reviews.ts
+++ b/fixtures/reviews.ts
@@ -2,9 +2,37 @@ const reviews = [
   {
     description:
       '사장님이 추천해주셔서 감자튀김도 먹었습니다! 정말 맛있었고, 소스도 훌륭했던 것 같아요~',
-    pictureUrl: 'https://picsum.photos/200',
+    pictureUrl: 'https://picsum.photos/201',
     author: '카즈마',
+    createAt: '20211211',
+  },
+  {
+    description:
+      '한 동안 가지 않았었는데, 이번에 모처럼 이벤트가 생겨서 놀러 가니, 너무 재밌게 놀고 왔어요!!',
+    pictureUrl: 'https://picsum.photos/202',
+    author: '젱영',
+    createAt: '20211203',
+  },
+  {
+    description:
+      '역시 좋은 뷰에서 마시니, 가격도 분위기도 굉장히 만족스러웠답니다 :)',
+    pictureUrl: 'https://picsum.photos/203',
+    author: '재영',
+    createAt: '20211121',
+  },
+  {
+    description:
+      '할인 이벤트 겸 다같이 2차로 간단히 맥주 마시기에 굉장히 나쁘지 않은 너ㅡ낌이었어요!',
+    pictureUrl: 'https://picsum.photos/204',
+    author: '제이슨',
     createAt: '20211201',
+  },
+  {
+    description:
+      '저희 집 강아지도 여기 맥주가 너무 좋다지 뭐에요?! 다음에 이벤트 또 열리면 포미 또 데려와야겠어요~',
+    pictureUrl: 'https://picsum.photos/205',
+    author: 'Jason',
+    createAt: '20211126',
   },
 ];
 export default reviews;

--- a/src/components/domains/CategoryList.tsx
+++ b/src/components/domains/CategoryList.tsx
@@ -52,9 +52,15 @@ const CategoryList = ({
   margin = 0,
   onClick,
   flexType = 'column',
+  ...props
 }: CategoryListProps) => {
   return (
-    <StyledCategoryList width={width} padding={padding} margin={margin}>
+    <StyledCategoryList
+      width={width}
+      padding={padding}
+      margin={margin}
+      {...props}
+    >
       <header>
         <HeaderCategoryTitle headerMarginBottom={headerMarginBottom}>
           <HeaderText level={headerLevel}>{categoryName}</HeaderText>

--- a/src/components/domains/ReviewCard.tsx
+++ b/src/components/domains/ReviewCard.tsx
@@ -26,6 +26,20 @@ const ImageContainerCSS = css`
   margin-right: 16px;
 `;
 
+const CardFooterBox = styled.div`
+  position: relative;
+  bottom: 0;
+  display: flex;
+  justify-content: space-between;
+  ${TextMarginBottomCSS}
+`;
+
+const StyledDescriptionBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
 interface reviewDataTypes {
   marketName?: string;
   pictureUrl: string | undefined;
@@ -59,7 +73,7 @@ const ReviewCard = ({
   return (
     <CardContainer
       cardType={cardType}
-      padding="24px 16px"
+      padding="20px 16px"
       marginWidth={marginWidth}
       marginHeight={marginHeight}
       css={CardBackgroundCSS}
@@ -69,8 +83,11 @@ const ReviewCard = ({
           <Text block size="small" css={DescriptionMarginBottomCSS}>
             {reviewData.description}
           </Text>
-          <Text block size="micro" css={TextMarginBottomCSS}>
+          <Text block size="micro">
             2021.12.09
+          </Text>
+          <Text block size="micro" css={TextMarginBottomCSS}>
+            {`by ${reviewData.author}`}
           </Text>
           <Text block size="micro">
             {reviewData.marketName || ''}
@@ -81,18 +98,23 @@ const ReviewCard = ({
           <ImageContainer
             src={reviewData.pictureUrl as string}
             alt="리뷰 사진"
-            width={72}
-            height={72}
+            width={80}
+            height={80}
             css={ImageContainerCSS}
           />
-          <div>
+          <StyledDescriptionBox>
             <Text block size="small" css={TextMarginBottomCSS}>
               {reviewData.description}
             </Text>
-            <Text block size="micro" css={TextMarginBottomCSS}>
-              2021.12.09
-            </Text>
-          </div>
+            <CardFooterBox>
+              <Text block size="micro">
+                2021.12.09
+              </Text>
+              <Text block size="micro">
+                {`by ${reviewData.author}`}
+              </Text>
+            </CardFooterBox>
+          </StyledDescriptionBox>
         </DefaultTypeReviewInner>
       )}
     </CardContainer>

--- a/src/components/domains/ReviewCard.tsx
+++ b/src/components/domains/ReviewCard.tsx
@@ -30,10 +30,19 @@ interface reviewDataTypes {
   marketName?: string;
   pictureUrl: string | undefined;
   description: string;
+  [prop: string]: any;
 }
+interface EventReviewPageDataTypes {
+  pictureUrl: string | undefined;
+  description: string;
+  author: string;
+  createAt: string;
+  [prop: string]: any;
+}
+
 interface ReviewCardProps {
   cardType: 'default' | 'box';
-  reviewData: reviewDataTypes;
+  reviewData: reviewDataTypes | EventReviewPageDataTypes;
   marginWidth?: string | number;
   marginHeight?: string | number;
   [prop: string]: any;

--- a/src/pages/event/[eventId]/reviews.tsx
+++ b/src/pages/event/[eventId]/reviews.tsx
@@ -1,10 +1,39 @@
-import { useRouter } from 'next/dist/client/router';
+import { MainContainer } from '@components/atoms';
+import { CategoryList, Header } from '@components/domains';
+import ReviewCard from '@components/domains/ReviewCard';
+import { css } from '@emotion/react';
+import reviews from 'fixtures/reviews';
 import React from 'react';
 
+const CategoryListCSS = css`
+  margin-top: 20px;
+`;
+
 const ReviewDetailPage = () => {
-  const router = useRouter();
-  const { eventId } = router.query;
-  return <div>{eventId} 리뷰 상세 페이지</div>;
+  return (
+    <MainContainer paddingWidth={24}>
+      <Header />
+      <CategoryList
+        headerLevel={2}
+        headerMarginBottom={16}
+        categoryName="이벤트 리뷰"
+        padding={0}
+        margin={0}
+        flexType="column"
+        width="auto"
+        css={CategoryListCSS}
+      >
+        {reviews.map((review, id) => (
+          <ReviewCard
+            key={`${`${review}${id}`}`}
+            cardType="default"
+            reviewData={{ ...review, marketName: '오비맥주 광진점' }}
+            marginHeight={8}
+          />
+        ))}
+      </CategoryList>
+    </MainContainer>
+  );
 };
 
 export default ReviewDetailPage;

--- a/src/pages/event/[eventId]/reviews.tsx
+++ b/src/pages/event/[eventId]/reviews.tsx
@@ -1,7 +1,8 @@
 import { MainContainer } from '@components/atoms';
-import { CategoryList, Header } from '@components/domains';
+import { CategoryList, EventDetailHeader, Header } from '@components/domains';
 import ReviewCard from '@components/domains/ReviewCard';
 import { css } from '@emotion/react';
+import event from 'fixtures/event';
 import reviews from 'fixtures/reviews';
 import React from 'react';
 
@@ -10,9 +11,19 @@ const CategoryListCSS = css`
 `;
 
 const ReviewDetailPage = () => {
+  const { expiredAt, marketName, name, isLike, isFavorite, isParticipated } =
+    event;
   return (
     <MainContainer paddingWidth={24}>
       <Header />
+      <EventDetailHeader
+        expiredAt={expiredAt}
+        marketName={marketName}
+        name={name}
+        isLike={isLike}
+        isFavorite={isFavorite}
+        isParticipated={isParticipated}
+      />
       <CategoryList
         headerLevel={2}
         headerMarginBottom={16}

--- a/src/stories/domains/ReviewCard.stories.tsx
+++ b/src/stories/domains/ReviewCard.stories.tsx
@@ -31,6 +31,7 @@ export const Default: ComponentStory<typeof ReviewCard> = (args) => {
     description:
       '회덮밥이 너무나 맛있었어요~ 너무나 맛난 저녁에다 맥주 공짜로 먹어서 좋았어요!',
     marketName: '티모네 횟집',
+    author: '젱영',
     pictureUrl: 'https://picsum.photos/200',
   };
   return (


### PR DESCRIPTION
## PR 설명
- [x] 이벤트 리뷰를 자세히 볼 수 있는 페이지인 이벤트 리뷰 페이지 레이아웃을 구현한다.
- [x] ReviewCard에서 author에 대한 정보를 볼 수 있다.
## 결과
### 레이아웃
![image](https://user-images.githubusercontent.com/78713176/145700644-5bf17e8b-af2a-487c-9819-05c1847ff88d.png)

## ReviewCard Author 추가
![리뷰카드 생성](https://user-images.githubusercontent.com/78713176/145702683-9f5037f4-81a2-42b7-8ef1-b8b2bfa9f89e.gif)

## 구현 중 생긴 건의 사항
1. EventReviewPage에서 받을 Review 데이터에서도 marketName을 받아야 한다.
2. 혹은, 이벤트 정보를 건네 받을 때, Review 데이터를 조인 받아서, 그 데이터를 사용해도 좋을 듯하다.