### PR TITLE
[TLVB-108] 가게보기(내 가게) 페이지 레이아웃 구성

### DIFF
--- a/fixtures/shop.ts
+++ b/fixtures/shop.ts
@@ -1,9 +1,10 @@
 // TODO: 가게의 정보를 조회할 수 있다.
 
 const shopInfo = {
-  marketId: '오비맥주 광진점',
+  marketName: '오비맥주 광진점',
+  description: '매일 새롭게 따르는 생맥주를 맛보세요~!',
   eventCount: '4',
-  likeCount: '329',
+  favoriteCount: '329',
   reviewCount: '72',
 };
 

--- a/fixtures/shopEvents.ts
+++ b/fixtures/shopEvents.ts
@@ -22,14 +22,14 @@ const shopEvents = [
     reviewCount: '90',
   },
   {
-    name: '생맥주 1700ml 시키면 생맥주 500ml 더!',
+    name: '생맥주 1700ml 주문시 500ml 더!',
     expiredAt: '20210921',
     marketName: '오비맥주 광진점',
     likeCount: '981',
     reviewCount: '165',
   },
   {
-    name: '코로나 같이 이겨봐요! 맥주 전 종류 10% 할인',
+    name: '코로나 같이 이겨봐요!',
     expiredAt: '20210816',
     marketName: '오비맥주 광진점',
     likeCount: '32',

--- a/src/components/domains/EventCard.tsx
+++ b/src/components/domains/EventCard.tsx
@@ -78,7 +78,9 @@ const EventCard = ({
       <Text block bold css={marginBottomCSS('16')}>
         {name}
       </Text>
-      <Text block size="micro">{`${maxParticipants}명 남음`}</Text>
+      <Text block size="micro">
+        {maxParticipants ? `${maxParticipants}명 남음` : ``}
+      </Text>
       <Text block size="micro">
         {marketName}
       </Text>

--- a/src/components/domains/ShopDetail/ShopAddEvent.tsx
+++ b/src/components/domains/ShopDetail/ShopAddEvent.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Text } from '@components/atoms';
+import styled from '@emotion/styled';
+import Common from '@styles/index';
+
+const ShopAddEventWrapper = styled.button`
+  all: unset;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 308px;
+  height: 118px;
+  background: ${Common.colors.background};
+  border: 2px dashed ${Common.colors.point};
+  border-radius: 16px;
+
+  &:hover {
+    cursor: pointer;
+    background-color: rgb(0 0 0 / 5%);
+  }
+`;
+
+const ShopAddEvent = () => {
+  // TODO: 이벤트 생성 페이지로 라우팅 처리할 예정
+  const handleClick = () => {};
+
+  return (
+    <ShopAddEventWrapper onClick={handleClick}>
+      <Text size={48} color={Common.colors.point}>
+        +
+      </Text>
+      <Text size="small" color={Common.colors.point}>
+        이벤트 만들기
+      </Text>
+    </ShopAddEventWrapper>
+  );
+};
+
+export default ShopAddEvent;

--- a/src/components/domains/ShopDetail/ShopCountInfo.tsx
+++ b/src/components/domains/ShopDetail/ShopCountInfo.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Text } from '@components/atoms';
+import { Shop } from '@contexts/Shop/types';
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import Common from '@styles/index';
+
+const ShopCountInfoWrapper = styled.div`
+  display: grid;
+  grid-template-rows: repeat(3, 1fr);
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+  text-align: center;
+`;
+
+const CountCSS = css`
+  font-weight: bold;
+`;
+
+interface ShopCountInfoProps extends Partial<Shop> {
+  [index: string]: any;
+}
+
+const ShopCountInfo = ({
+  eventCount,
+  favoriteCount,
+  reviewCount,
+}: ShopCountInfoProps) => {
+  return (
+    <ShopCountInfoWrapper>
+      <Text color={Common.colors.point} css={CountCSS}>
+        {(eventCount || 0).toString()}
+      </Text>
+      <Text color={Common.colors.point} css={CountCSS}>
+        {(favoriteCount || 0).toString()}
+      </Text>
+      <Text color={Common.colors.point} css={CountCSS}>
+        {(reviewCount || 0).toString()}
+      </Text>
+      <Text size="small">이벤트 진행</Text>
+      <Text size="small">받은 좋아요</Text>
+      <Text size="small">받은 리뷰</Text>
+    </ShopCountInfoWrapper>
+  );
+};
+
+export default ShopCountInfo;

--- a/src/components/domains/ShopDetail/ShopDetailHeader.tsx
+++ b/src/components/domains/ShopDetail/ShopDetailHeader.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { HeaderText, Text } from '@components/atoms';
+import { Shop } from '@contexts/Shop/types';
+import styled from '@emotion/styled';
+
+const ShopDetailHeaderWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: left;
+  margin-top: 58px;
+  margin-bottom: 24px;
+`;
+
+const ShopDescriptionWrapper = styled.div`
+  display: flex;
+  gap: 30px;
+  width: 318px;
+`;
+
+const EditButton = styled.button`
+  all: unset;
+`;
+
+interface ShopDetailHeaderProps extends Partial<Shop> {
+  [index: string]: any;
+}
+
+const ShopDetailHeader = ({
+  marketName,
+  description,
+}: ShopDetailHeaderProps) => {
+  return (
+    <ShopDetailHeaderWrapper>
+      <HeaderText level={1} marginBottom={24}>
+        {marketName}
+      </HeaderText>
+      <ShopDescriptionWrapper>
+        <Text size="small" block fontStyle={{ overflow: 'hidden' }}>
+          {description || '가게소개가 없어요!'}
+        </Text>
+        <EditButton>✏️</EditButton>
+      </ShopDescriptionWrapper>
+    </ShopDetailHeaderWrapper>
+  );
+};
+
+export default ShopDetailHeader;

--- a/src/components/domains/ShopDetail/ShopEvents.tsx
+++ b/src/components/domains/ShopDetail/ShopEvents.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { CardList } from '@components/atoms';
+import { EventCard } from '@components/domains';
+import { ShopEvent } from '@contexts/Shop/types';
+
+interface ShopEventsProps extends Partial<ShopEvent> {
+  [index: string]: any;
+}
+
+// TODO: 각 이벤트 카드에 대한 라우팅 처리할 예정
+const handleClick = () => {};
+
+const ShopEvents = ({ events }: ShopEventsProps) => {
+  const defaultData = {
+    isLike: true,
+  };
+
+  return (
+    <CardList flexType="column" padding={0} margin="10px 0 0 0">
+      {events.map((event: any, index: number) => (
+        <EventCard
+          onClick={() => handleClick()}
+          key={`${`${event}${index}`}`}
+          eventData={{ ...defaultData, ...event }}
+          idx={index}
+          marginHeight={10}
+        />
+      ))}
+    </CardList>
+  );
+};
+
+export default ShopEvents;

--- a/src/components/domains/ShopDetail/index.tsx
+++ b/src/components/domains/ShopDetail/index.tsx
@@ -1,0 +1,4 @@
+export { default as ShopDetailHeader } from './ShopDetailHeader';
+export { default as ShopCountInfo } from './ShopCountInfo';
+export { default as ShopAddEvent } from './ShopAddEvent';
+export { default as ShopEvents } from './ShopEvents';

--- a/src/contexts/Shop/types.ts
+++ b/src/contexts/Shop/types.ts
@@ -1,0 +1,15 @@
+export interface Shop {
+  marketName: string | null;
+  description: string | null;
+  eventCount: number | null;
+  favoriteCount: number | null;
+  reviewCount: number | null;
+}
+
+export interface ShopEvent {
+  name: string | null;
+  expiredAt: string | null;
+  marketName: string | null;
+  favoriteCount: number | null;
+  reviewCount: number | null;
+}

--- a/src/pages/shop/[shopId]/index.tsx
+++ b/src/pages/shop/[shopId]/index.tsx
@@ -1,10 +1,50 @@
 import { useRouter } from 'next/dist/client/router';
 import React from 'react';
+import { MainContainer } from '@components/atoms';
+import { Header } from '@components/domains/index';
+import {
+  ShopDetailHeader,
+  ShopCountInfo,
+  ShopAddEvent,
+  ShopEvents,
+} from '@components/domains/ShopDetail/index';
+import shopData from 'fixtures/shop';
+import shopEventData from 'fixtures/shopEvents';
+import styled from '@emotion/styled';
+
+const EventContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
 
 const ShopDetailPage = () => {
   const router = useRouter();
   const { shopId } = router.query;
-  return <div>{shopId}가게 상세 조회 페이지</div>;
+
+  // TODO: shopId에 대한 처리할 예정
+  /* eslint-disable no-console */
+  console.log(shopId);
+
+  const { marketName, description, eventCount, favoriteCount, reviewCount } =
+    shopData;
+
+  return (
+    <MainContainer>
+      <Header />
+      <ShopDetailHeader marketName={marketName} description={description} />
+      <EventContentWrapper>
+        <ShopCountInfo
+          eventCount={Number(eventCount)}
+          favoriteCount={Number(favoriteCount)}
+          reviewCount={Number(reviewCount)}
+        />
+        <ShopAddEvent />
+        <ShopEvents events={shopEventData} />
+      </EventContentWrapper>
+    </MainContainer>
+  );
 };
 
 export default ShopDetailPage;


### PR DESCRIPTION
## 구현사항
* 사업자의 가게보기 페이지 레이아웃을 구성
![shopDetail_layout](https://user-images.githubusercontent.com/71805803/145961570-1f2b2e6c-013d-403c-bdd4-fb906e7b353c.gif)


## 참고사항
* 현재 mock data로 레이아웃이 구성되어있습니다.

* 추후 구현 사항
   * context 관련 API연동
   * 가게 설명 수정 펜슬 아이콘 클릭 시 수정영역 나오게 하는 것
   * 이벤트만들기 클릭 시 이벤트 생성 페이지 라우팅 처리
   * 이벤트 카드 클릭 시 이벤트 상세 페이지 라우팅 처리
   * 타입(형변환)관련 리팩토링
   * 설명 길이 등에 대한 컴포넌트 처리