### PR TITLE
[TLVB-135] 리뷰 페이지 무한 스크롤 구현

### DIFF
--- a/src/components/domains/ReviewCard.tsx
+++ b/src/components/domains/ReviewCard.tsx
@@ -40,7 +40,7 @@ const StyledDescriptionBox = styled.div`
   justify-content: space-between;
 `;
 
-interface reviewDataTypes {
+export interface reviewDataTypes {
   marketName?: string;
   pictureUrl: string | undefined;
   description: string;

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 
 interface useIntersectionObserverTypes {
-  lastIdCurrent: number | string;
+  lastIdCurrent: number;
   observerCallback: (
     entries: IntersectionObserverEntry[],
     observer: IntersectionObserver

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from 'react';
+
+interface useIntersectionObserverTypes {
+  lastIdCurrent: number | string;
+  observerCallback: (
+    entries: IntersectionObserverEntry[],
+    observer: IntersectionObserver
+  ) => void;
+  observerOptions: {
+    root?: Element | Document | null;
+    rootMargin?: string;
+    threshold?: number | number[];
+  };
+}
+const useIntersectionObserver = ({
+  lastIdCurrent,
+  observerCallback,
+  observerOptions,
+}: useIntersectionObserverTypes) => {
+  const observerTarget = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let observerRef: HTMLDivElement | null = null;
+    if (observerTarget.current) {
+      observerRef = observerTarget.current;
+    }
+
+    const observer = new IntersectionObserver(
+      observerCallback,
+      observerOptions
+    );
+
+    observer.observe(observerRef as HTMLElement);
+    return () => {
+      observer.unobserve(observerRef as HTMLElement);
+    };
+
+    // TODO: 현재 lastIdCurrent가 변경될 때마다 observer을 만들고 해제할 수 있도록 한다.
+    /* eslint-disable react-hooks/exhaustive-deps */
+  }, [lastIdCurrent]);
+
+  return {
+    observerTarget,
+  };
+};
+
+export default useIntersectionObserver;

--- a/src/pages/event/[eventId]/reviews.tsx
+++ b/src/pages/event/[eventId]/reviews.tsx
@@ -1,11 +1,11 @@
 import { MainContainer } from '@components/atoms';
 import { CategoryList, EventDetailHeader, Header } from '@components/domains';
-import ReviewCard from '@components/domains/ReviewCard';
+import ReviewCard, { reviewDataTypes } from '@components/domains/ReviewCard';
 import { EventDetail } from '@contexts/event/types';
 import { css } from '@emotion/react';
 import event from 'fixtures/event';
 import reviews from 'fixtures/reviews';
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 const CategoryListCSS = css`
   margin-top: 20px;
@@ -20,6 +20,56 @@ const ReviewDetailPage = () => {
     isFavorite,
     isParticipated,
   }: EventDetail = event;
+
+  const lastReviewId = useRef<number>(0);
+  const observerTarget = useRef<HTMLDivElement>(null);
+  const [nowReviews, setNowReviews] = useState<any[]>(reviews);
+
+  useEffect(() => {
+    let observerRef: HTMLDivElement | null = null;
+    if (observerTarget.current) {
+      observerRef = observerTarget.current;
+    }
+    const observerCallback = (
+      entries: IntersectionObserverEntry[],
+      observer: IntersectionObserver
+    ) => {
+      entries.forEach((entry: IntersectionObserverEntry) => {
+        // TODO: lastReviewId가 현재 마지막 리뷰와 같다면 early return한다.
+        if (lastReviewId.current > 3) {
+          observer.unobserve(entry.target);
+        }
+
+        if (entry.isIntersecting) {
+          // TODO: API 요청에 페이지를 담아 전달한다. cnt를 업데이트한다. (실제로는 마지막 리뷰 id)
+          setNowReviews((state) => [...state, ...reviews]);
+          lastReviewId.current += 1;
+
+          // TODO: 만약 요청을 했을 때 더이상 추가할 수 없다면 observe를 추가하지 않는다.
+          if (lastReviewId.current > 3) {
+            observer.unobserve(entry.target);
+          }
+          // if (lastReviewId.current === lastCnt + 1) observer.observe(entry.target);
+        }
+      });
+    };
+    const observerOptions = {
+      root: null,
+      rootMargin: '0px 0px 200px 0px',
+      threshold: 1,
+    };
+    const observer = new IntersectionObserver(
+      observerCallback,
+      observerOptions
+    );
+    observer.observe(observerRef as HTMLElement);
+    return () => {
+      observer.unobserve(observerRef as HTMLElement);
+    };
+    // TODO: 현재 scrollCnt가 늘어날 때마다 observer을 만들고 해제할 수 있도록 한다.
+    /* eslint-disable react-hooks/exhaustive-deps */
+  }, [lastReviewId.current]);
+
   return (
     <MainContainer paddingWidth={24}>
       <Header />
@@ -41,7 +91,7 @@ const ReviewDetailPage = () => {
         width="auto"
         css={CategoryListCSS}
       >
-        {reviews.map((review, id) => (
+        {nowReviews.map((review: reviewDataTypes, id: number) => (
           <ReviewCard
             key={`${`${review}${id}`}`}
             cardType="default"
@@ -50,6 +100,7 @@ const ReviewDetailPage = () => {
           />
         ))}
       </CategoryList>
+      <div ref={observerTarget} />
     </MainContainer>
   );
 };


### PR DESCRIPTION
## PR 설명
API 적용 전에 리소스 낭비를 최소화하기 위해 카드 및 리뷰들을 조회할 때 필요한 무한 스크롤을 구현한다.

## 상세 시나리오
[x] 사용자는 스크롤을 할 때 자동으로 n개의 리뷰를 더 볼 수 있다.
[x] 사용자가 스크롤을 끝까지 내렸을 때, 더 이상 요청할 것이 없다면 동작하지 않는다.

## 시연 영상
![무한스크롤 구현](https://user-images.githubusercontent.com/78713176/146334893-ec205ab0-78ec-4cfa-8e94-a40714ad7e66.gif)
