### PR TITLE
[TLVB-168] 이벤트 리뷰 생성 형식에 맞춰 구현

### DIFF
--- a/src/axios/review/createReview.ts
+++ b/src/axios/review/createReview.ts
@@ -9,14 +9,15 @@ const createReview = async ({
   picture,
 }: CreateReviewParams) => {
   const formData = new FormData();
-  formData.append('picture', picture);
+  formData.append('file', picture);
+  formData.append(
+    'request',
+    new Blob([JSON.stringify({ description })], { type: 'application/json' })
+  );
   const res: ResType<Review> = await request.post(
     `/events/${eventId}/reviews`,
+    formData,
     {
-      data: {
-        description,
-        picture: formData,
-      },
       headers: {
         'Content-Type': 'multipart/form-data',
       },


### PR DESCRIPTION
# PR 형식
리뷰 작성 API의 형식에 맞춰 요청 body 형식을 변경하였습니다.

# 문제의 원인
현재 FormData 내부에 있는 데이터 역시 content의 type을 지정해줘야 했습니다.

# 해결 방법
`Blob`이라는 객체를 활용하여 타입을 지정해주었습니다. (File보다 더욱 추상적인 데이터 미가공 형식에 대한 객체)

# 결과
잘 동작합니다!
![image](https://user-images.githubusercontent.com/78713176/146664620-794a2382-7cbe-4ab4-a769-94471302a320.png)

# 참고 자료
현재 해결 방식에 사용한 `Blob` 객체에 대하여 TWL을 작성하였습니다.
[Blob에 대해 간단히 톺아 보는 글](https://oranjik.notion.site/new-Blob-fc1d53549b6a4cbc9002e3bb9d19ef51)