### PR TITLE
[TLVB-171] 프로필수정페이지 구현 및 Tab 버튼 조건부 렌더링

### DIFF
--- a/src/axios/user.ts
+++ b/src/axios/user.ts
@@ -34,3 +34,11 @@ export const onRegisterCheck = async (check: OverlapCheckInfo) => {
 
   return res;
 };
+
+export const onConfirmPassword = async (password: 'passwordConfirm') => {
+  const res: ResType<any> = await request.post('/members/check/password', {
+    password,
+  });
+
+  return res;
+};

--- a/src/components/atoms/TabButton.tsx
+++ b/src/components/atoms/TabButton.tsx
@@ -19,6 +19,8 @@ export interface TabButtonProps {
   block?: boolean;
   isLeft?: boolean;
   isLeftFocused?: boolean;
+  id?: string;
+  onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
   display?: 'none' | 'flex';
 }
 
@@ -59,12 +61,12 @@ const TabButton: React.FC<TabButtonProps> = ({
   isLeft = true,
   isLeftFocused = true,
   color,
+  onClick,
   backgroundColor,
   ...props
 }) => {
   return (
     <StyledTab
-      {...props}
       width={width}
       height={height}
       margin={margin}
@@ -72,6 +74,8 @@ const TabButton: React.FC<TabButtonProps> = ({
       isLeft={isLeft}
       isLeftFocused={isLeftFocused}
       backgroundColor={backgroundColor}
+      onClick={onClick}
+      {...props}
     >
       <Text>{children}</Text>
     </StyledTab>

--- a/src/components/domains/OverlapCheck.tsx
+++ b/src/components/domains/OverlapCheck.tsx
@@ -9,6 +9,7 @@ interface Props {
   name: string;
   error: boolean;
   buttonText: string;
+  inputType?: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onClick: (e: React.MouseEvent) => void;
 }
@@ -31,6 +32,7 @@ const OverlapCheck: React.FC<Props> = ({
   name,
   error,
   buttonText,
+  inputType = 'text',
   onChange,
   onClick,
   placeholder = '이메일',
@@ -40,6 +42,7 @@ const OverlapCheck: React.FC<Props> = ({
     <Container {...props}>
       <Input
         sizeType="small"
+        type={inputType}
         name={name}
         error={error}
         onChange={onChange}

--- a/src/components/domains/PasswordForm.tsx
+++ b/src/components/domains/PasswordForm.tsx
@@ -1,0 +1,41 @@
+import { Input } from '@components/atoms';
+import { marginBottom } from '@utils/computed';
+import React from 'react';
+
+type Error = {
+  [key: string]: any;
+  password: boolean;
+  passwordCheck: boolean;
+};
+
+interface Props {
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  error: boolean | Error;
+}
+
+const PasswordForm: React.FC<Props> = ({ onChange, error }) => {
+  return (
+    <>
+      <Input
+        sizeType="small"
+        placeholder="비밀번호"
+        type="password"
+        name="password"
+        onChange={onChange}
+        error={typeof error === 'boolean' ? error : error.password}
+        css={marginBottom(8)}
+      />
+      <Input
+        sizeType="small"
+        placeholder="비밀번호 확인"
+        type="password"
+        name="passwordCheck"
+        onChange={onChange}
+        error={typeof error === 'boolean' ? error : error.passwordCheck}
+        css={marginBottom(8)}
+      />
+    </>
+  );
+};
+
+export default PasswordForm;

--- a/src/components/domains/ProfileEdit.tsx
+++ b/src/components/domains/ProfileEdit.tsx
@@ -8,7 +8,7 @@ import Common from '@styles/index';
 import { ErrorProfile, ProfileUserInfo } from '@contexts/UserContext/types';
 import { text } from '@utils/constantUser';
 import { onConfirmPassword, onRegisterCheck } from '@axios/user';
-import { useRouter } from 'next/router';
+// import { useRouter } from 'next/router';
 import OverlapCheck from './OverlapCheck';
 import Tab from './Tab';
 
@@ -34,7 +34,7 @@ const marginBottom = (size: number) => css`
 
 const ProfileEdit: React.FC<Props> = ({ email, children, ...props }) => {
   const { state } = useContext(UserContext);
-  const router = useRouter();
+  // const router = useRouter();
   const [buttonFocus, setButtonFocus] = useState(true);
   const [passwordConfirm, setPasswordConfirm] = useState(false);
   const [successNicknameMessage, setSuccessNicknameMessage] = useState(false);
@@ -46,17 +46,15 @@ const ProfileEdit: React.FC<Props> = ({ email, children, ...props }) => {
         password: '',
         passwordCheck: '',
       },
-      onSubmit: (values) => {
+      onSubmit: (formData) => {
         if (!passwordConfirm) return;
-        if (values.nickname && !successNicknameMessage) return;
-
+        if (formData.nickname && !successNicknameMessage) return;
+        // eslint-disable-next-line
         const profileEditUserInfo = {
-          nickname: values.nickname === '' ? undefined : values.nickname,
-          password: values.password === '' ? undefined : values.password,
+          nickname: formData.nickname === '' ? undefined : formData.nickname,
+          password: formData.password === '' ? undefined : formData.password,
         };
-
         // API 전송
-        console.log(profileEditUserInfo);
       },
       validate: ({ password }) => {
         const newErrors: ErrorProfile = {};

--- a/src/components/domains/ProfileEdit.tsx
+++ b/src/components/domains/ProfileEdit.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useContext, useState } from 'react';
 import styled from '@emotion/styled';
-import { Button, HeaderText, Input, Text } from '@components/atoms';
+import { Button, HeaderText, Text } from '@components/atoms';
 import { css } from '@emotion/react';
 import UserContext from '@contexts/UserContext';
 import useForm from '@hooks/useForm';
@@ -11,6 +11,7 @@ import { onConfirmPassword, onRegisterCheck } from '@axios/user';
 // import { useRouter } from 'next/router';
 import OverlapCheck from './OverlapCheck';
 import Tab from './Tab';
+import PasswordForm from './PasswordForm';
 
 interface Props {
   children?: ReactNode;
@@ -231,24 +232,7 @@ const ProfileEdit: React.FC<Props> = ({ email, children, ...props }) => {
           <HeaderText level={2} marginBottom={16}>
             비밀번호 변경
           </HeaderText>
-          <Input
-            sizeType="small"
-            placeholder="비밀번호"
-            type="password"
-            name="password"
-            onChange={handleChange}
-            error={false}
-            css={marginBottom(8)}
-          />
-          <Input
-            sizeType="small"
-            placeholder="비밀번호 확인"
-            type="password"
-            name="passwordCheck"
-            onChange={handleChange}
-            error={false}
-            css={marginBottom(8)}
-          />
+          <PasswordForm onChange={handleChange} error={false} />
           <Text
             size="micro"
             fontStyle={{ display: 'flex', justifyContent: 'center' }}

--- a/src/components/domains/ProfileEdit.tsx
+++ b/src/components/domains/ProfileEdit.tsx
@@ -1,7 +1,8 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useState } from 'react';
 import styled from '@emotion/styled';
 import { Button, HeaderText, Input, Text } from '@components/atoms';
 import { css } from '@emotion/react';
+import OverlapCheck from './OverlapCheck';
 import Tab from './Tab';
 
 interface Props {
@@ -10,16 +11,14 @@ interface Props {
 }
 
 const ProfileEditContainer = styled.div`
+  width: 280px;
   margin-top: 60px;
 `;
 
-const CheckWrapper = styled.div`
+const ModifyWrapper = styled.div`
   display: flex;
   flex-direction: column;
-`;
-
-const ButtonRight = css`
-  margin-left: auto;
+  margin-bottom: 32px;
 `;
 
 const marginBottom = (size: number) => css`
@@ -27,6 +26,15 @@ const marginBottom = (size: number) => css`
 `;
 
 const ProfileEdit: React.FC<Props> = ({ email, children, ...props }) => {
+  const [buttonFocus, setButtonFocus] = useState(true);
+
+  const handlerChangeTab = (e: React.MouseEvent) => {
+    const { id } = e.currentTarget as HTMLElement;
+
+    if (id === 'left') setButtonFocus(true);
+    else if (id === 'right') setButtonFocus(false);
+  };
+
   return (
     <ProfileEditContainer {...props}>
       <HeaderText level={1} marginBottom={43}>
@@ -38,65 +46,66 @@ const ProfileEdit: React.FC<Props> = ({ email, children, ...props }) => {
       <Text block size="medium" css={marginBottom(16)}>
         {email}
       </Text>
-      <HeaderText level={2} marginBottom={16}>
-        비밀번호
-      </HeaderText>
-      <CheckWrapper css={marginBottom(16)}>
-        <Input
-          type="password"
-          sizeType="small"
+      <ModifyWrapper css={marginBottom(16)}>
+        <HeaderText level={2} marginBottom={16}>
+          비밀번호
+        </HeaderText>
+        <OverlapCheck
+          placeholder="비밀번호 입력"
           name="password"
           error={false}
-          placeholder="비밀번호입력"
-          css={marginBottom(16)}
+          buttonText="비밀번호 확인"
+          onChange={(e) => {}}
+          onClick={(e) => {}}
         />
-        <Button reversal border width={95} css={ButtonRight}>
-          비밀번호 확인
-        </Button>
-      </CheckWrapper>
+      </ModifyWrapper>
       <Tab
         width={279}
+        isLeft
+        isLeftFocused={buttonFocus}
         leftText="닉네임 변경"
         rightText="비밀번호 변경"
+        onClick={handlerChangeTab}
         css={marginBottom(16)}
       />
-      <HeaderText level={2} marginBottom={16}>
-        닉네임 변경
-      </HeaderText>
-      <CheckWrapper css={marginBottom(32)}>
-        <Input
-          type="password"
-          sizeType="small"
-          name="password"
-          error={false}
-          placeholder="닉네임"
-          css={marginBottom(16)}
-        />
-        <Button reversal border width={95} css={ButtonRight}>
-          중복 확인
-        </Button>
-      </CheckWrapper>
-      <CheckWrapper css={marginBottom(32)}>
-        <HeaderText level={2} marginBottom={16}>
-          비밀번호 변경
-        </HeaderText>
-        <Input
-          sizeType="small"
-          placeholder="비밀번호"
-          type="password"
-          name="password"
-          css={marginBottom(8)}
-          error={false}
-        />
-        <Input
-          sizeType="small"
-          placeholder="비밀번호 확인"
-          type="password"
-          name="passwordCheck"
-          css={marginBottom(8)}
-          error={false}
-        />
-      </CheckWrapper>
+
+      {buttonFocus ? (
+        <ModifyWrapper>
+          <HeaderText level={2} marginBottom={16}>
+            닉네임 변경
+          </HeaderText>
+          <OverlapCheck
+            placeholder="닉네임"
+            name="nickname"
+            error={false}
+            buttonText="닉네임 중복 확인"
+            onChange={(e) => {}}
+            onClick={(e) => {}}
+          />
+        </ModifyWrapper>
+      ) : (
+        <ModifyWrapper>
+          <HeaderText level={2} marginBottom={16}>
+            비밀번호 변경
+          </HeaderText>
+          <Input
+            sizeType="small"
+            placeholder="비밀번호"
+            type="password"
+            name="password"
+            css={marginBottom(8)}
+            error={false}
+          />
+          <Input
+            sizeType="small"
+            placeholder="비밀번호 확인"
+            type="password"
+            name="passwordCheck"
+            css={marginBottom(8)}
+            error={false}
+          />
+        </ModifyWrapper>
+      )}
       <Button>확인</Button>
     </ProfileEditContainer>
   );

--- a/src/components/domains/ProfileEdit.tsx
+++ b/src/components/domains/ProfileEdit.tsx
@@ -9,6 +9,7 @@ import { ErrorProfile, ProfileUserInfo } from '@contexts/UserContext/types';
 import { text } from '@utils/constantUser';
 import { onConfirmPassword, onRegisterCheck } from '@axios/user';
 // import { useRouter } from 'next/router';
+import { marginBottom } from '@utils/computed';
 import OverlapCheck from './OverlapCheck';
 import Tab from './Tab';
 import PasswordForm from './PasswordForm';
@@ -29,15 +30,13 @@ const ModifyWrapper = styled.div`
   margin-bottom: 32px;
 `;
 
-const marginBottom = (size: number) => css`
-  margin-bottom: ${size}px;
-`;
+const styleCenter = { display: 'flex', justifyContent: 'center' };
 
 const ProfileEdit: React.FC<Props> = ({ email, children, ...props }) => {
   const { state } = useContext(UserContext);
   // const router = useRouter();
   const [buttonFocus, setButtonFocus] = useState(true);
-  const [passwordConfirm, setPasswordConfirm] = useState(false);
+  const [passwordConfirm, setPasswordConfirm] = useState(true);
   const [successNicknameMessage, setSuccessNicknameMessage] = useState(false);
   const { values, errors, setErrors, handleChange, handleSubmit } =
     useForm<ProfileUserInfo>({
@@ -49,7 +48,12 @@ const ProfileEdit: React.FC<Props> = ({ email, children, ...props }) => {
       },
       onSubmit: (formData) => {
         if (!passwordConfirm) return;
-        if (formData.nickname && !successNicknameMessage) return;
+        if (formData.nickname && !successNicknameMessage) {
+          const newErrors: ErrorProfile = {};
+          newErrors.nickname = text.nicknameInput;
+          setErrors(newErrors);
+          return;
+        }
         // eslint-disable-next-line
         const profileEditUserInfo = {
           nickname: formData.nickname === '' ? undefined : formData.nickname,
@@ -79,10 +83,14 @@ const ProfileEdit: React.FC<Props> = ({ email, children, ...props }) => {
     delete newErrors[key];
 
     if (!values[key]) {
-      newErrors[key] =
-        key === 'passwordConfirm'
-          ? text.passwordConfirm
-          : text.overlap.nickname;
+      if (key === 'passwordConfirm') {
+        newErrors[key] = text.passwordConfirm;
+        setPasswordConfirm(false);
+      } else {
+        newErrors[key] = text.overlap.nickname;
+        setSuccessNicknameMessage(false);
+      }
+
       setErrors(newErrors);
       return;
     }
@@ -104,7 +112,6 @@ const ProfileEdit: React.FC<Props> = ({ email, children, ...props }) => {
         type: key,
         value: values[key],
       };
-
       res = await onRegisterCheck(checkInfo);
 
       if (res.error.code) {
@@ -152,12 +159,9 @@ const ProfileEdit: React.FC<Props> = ({ email, children, ...props }) => {
         {errors.passwordConfirm && (
           <Text
             size="micro"
-            fontStyle={{ display: 'flex', justifyContent: 'center' }}
-            block
+            fontStyle={styleCenter}
             color={Common.colors.warning}
-            css={css`
-              margin-bottom: 8px;
-            `}
+            css={marginBottom(8)}
           >
             {errors.passwordConfirm}
           </Text>
@@ -165,12 +169,9 @@ const ProfileEdit: React.FC<Props> = ({ email, children, ...props }) => {
         {passwordConfirm && (
           <Text
             size="micro"
-            fontStyle={{ display: 'flex', justifyContent: 'center' }}
-            block
+            fontStyle={styleCenter}
             color={Common.colors.point}
-            css={css`
-              margin-bottom: 8px;
-            `}
+            css={marginBottom(8)}
           >
             확인 완료됐습니다.
           </Text>
@@ -185,68 +186,63 @@ const ProfileEdit: React.FC<Props> = ({ email, children, ...props }) => {
         onClick={handleChangeTab}
         css={marginBottom(16)}
       />
-
-      {buttonFocus ? (
-        <ModifyWrapper>
-          <HeaderText level={2} marginBottom={16}>
-            닉네임 변경
-          </HeaderText>
-          <OverlapCheck
-            placeholder="닉네임"
-            name="nickname"
-            error={false}
-            buttonText="닉네임 중복 확인"
-            onChange={handleChange}
-            onClick={handleConfirm}
-          >
-            {errors.nickname && (
-              <Text
-                size="micro"
-                fontStyle={{ display: 'flex', justifyContent: 'center' }}
-                block
-                color={Common.colors.warning}
-                css={css`
-                  margin-bottom: 8px;
-                `}
-              >
-                {errors.nickname}
-              </Text>
-            )}
-            {successNicknameMessage && (
-              <Text
-                size="micro"
-                fontStyle={{ display: 'flex', justifyContent: 'center' }}
-                block
-                color={Common.colors.point}
-                css={css`
-                  margin-bottom: 8px;
-                `}
-              >
-                확인 완료됐습니다.
-              </Text>
-            )}
-          </OverlapCheck>
-        </ModifyWrapper>
-      ) : (
-        <ModifyWrapper>
-          <HeaderText level={2} marginBottom={16}>
-            비밀번호 변경
-          </HeaderText>
-          <PasswordForm onChange={handleChange} error={false} />
-          <Text
-            size="micro"
-            fontStyle={{ display: 'flex', justifyContent: 'center' }}
-            block
-            color={
-              errors.password
-                ? Common.colors.warning
-                : Common.colors.placeholder
-            }
-          >
-            {errors.password ? errors.password : text.default}
-          </Text>
-        </ModifyWrapper>
-      )}
+      <ModifyWrapper
+        css={css`
+          display: ${buttonFocus ? 'block' : 'none'};
+        `}
+      >
+        <HeaderText level={2} marginBottom={16}>
+          닉네임 변경
+        </HeaderText>
+        <OverlapCheck
+          placeholder="닉네임"
+          name="nickname"
+          error={false}
+          buttonText="닉네임 중복 확인"
+          onChange={handleChange}
+          onClick={handleConfirm}
+        >
+          {errors.nickname && (
+            <Text
+              size="micro"
+              fontStyle={styleCenter}
+              color={Common.colors.warning}
+              css={marginBottom(8)}
+            >
+              {errors.nickname}
+            </Text>
+          )}
+          {successNicknameMessage && (
+            <Text
+              size="micro"
+              fontStyle={styleCenter}
+              color={Common.colors.point}
+              css={marginBottom(8)}
+            >
+              확인 완료됐습니다.
+            </Text>
+          )}
+        </OverlapCheck>
+      </ModifyWrapper>
+      <ModifyWrapper
+        css={css`
+          display: ${buttonFocus ? 'none' : 'block'};
+        `}
+      >
+        <HeaderText level={2} marginBottom={16}>
+          비밀번호 변경
+        </HeaderText>
+        <PasswordForm onChange={handleChange} error={false} />
+        <Text
+          size="micro"
+          fontStyle={styleCenter}
+          color={
+            errors.password ? Common.colors.warning : Common.colors.placeholder
+          }
+        >
+          {errors.password ? errors.password : text.default}
+        </Text>
+      </ModifyWrapper>
       <Button onClick={handleSubmit}>확인</Button>
     </ProfileEditContainer>
   );

--- a/src/components/domains/RegisterForm.tsx
+++ b/src/components/domains/RegisterForm.tsx
@@ -1,6 +1,6 @@
 import React, { useReducer, useState } from 'react';
 import styled from '@emotion/styled';
-import { Button, Input, HeaderText, Text } from '@components/atoms';
+import { Button, HeaderText, Text } from '@components/atoms';
 import useForm from '@hooks/useForm';
 import Common from '@styles/index';
 import { onRegister, onRegisterCheck } from '@axios/user';
@@ -11,8 +11,9 @@ import {
 } from '@contexts/UserContext/types';
 import { registerReducer } from '@contexts/UserContext/reducer';
 import { useRouter } from 'next/router';
-import { css } from '@emotion/react';
+import { marginBottom } from '@utils/computed';
 import OverlapCheck from './OverlapCheck';
+import PasswordForm from './PasswordForm';
 
 const RegisterFormContainer = styled.div`
   display: flex;
@@ -28,10 +29,6 @@ const PasswordWrapper = styled.div`
 `;
 
 type OverlapParams = 'email' | 'nickname';
-
-const marginBottom = (size: string | number) => css`
-  margin-bottom: ${typeof size === 'string' ? size : `${size}px`};
-`;
 
 const RegisterForm = () => {
   const router = useRouter();
@@ -154,9 +151,7 @@ const RegisterForm = () => {
             fontStyle={{ display: 'flex', justifyContent: 'center' }}
             block
             color={Common.colors.warning}
-            css={css`
-              margin-bottom: 8px;
-            `}
+            css={marginBottom(8)}
           >
             {errors.email}
           </Text>
@@ -167,9 +162,7 @@ const RegisterForm = () => {
             fontStyle={{ display: 'flex', justifyContent: 'center' }}
             block
             color={Common.colors.point}
-            css={css`
-              margin-bottom: 8px;
-            `}
+            css={marginBottom(8)}
           >
             확인 완료됐습니다.
           </Text>
@@ -190,9 +183,7 @@ const RegisterForm = () => {
             fontStyle={{ display: 'flex', justifyContent: 'center' }}
             block
             color={Common.colors.warning}
-            css={css`
-              margin-bottom: 8px;
-            `}
+            css={marginBottom(8)}
           >
             {errors.nickname}
           </Text>
@@ -203,41 +194,19 @@ const RegisterForm = () => {
             fontStyle={{ display: 'flex', justifyContent: 'center' }}
             block
             color={Common.colors.point}
-            css={css`
-              margin-bottom: 8px;
-            `}
+            css={marginBottom(8)}
           >
             확인 완료됐습니다.
           </Text>
         )}
       </OverlapCheck>
       <PasswordWrapper>
-        <Input
-          sizeType="small"
-          placeholder="비밀번호"
-          type="password"
-          name="password"
-          css={css`
-            margin-bottom: 8px;
-          `}
-          onChange={onValidate}
-          error={validateErrors.password}
-        />
-        <Input
-          sizeType="small"
-          placeholder="비밀번호 확인"
-          type="password"
-          name="passwordCheck"
-          css={css`
-            margin-bottom: 8px;
-          `}
-          onChange={onValidate}
-          error={validateErrors.passwordCheck}
-        />
+        <PasswordForm onChange={onValidate} error={validateErrors} />
         <Text
           size="micro"
           fontStyle={{ display: 'flex', justifyContent: 'center' }}
           block
+          css={marginBottom(8)}
           color={
             errors.password ? Common.colors.warning : Common.colors.placeholder
           }
@@ -251,9 +220,6 @@ const RegisterForm = () => {
         height={48}
         borderRadius="15px"
         onClick={handleSubmit}
-        css={css`
-          margin-top: 8px;
-        `}
         bold
       >
         회원가입

--- a/src/components/domains/Tab.tsx
+++ b/src/components/domains/Tab.tsx
@@ -23,6 +23,7 @@ export interface TabProps {
   size?: string | number;
   leftText: string;
   rightText: string;
+  onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 const TabContainer: React.FC<Partial<TabProps>> = styled.div`
@@ -46,6 +47,7 @@ const Tab: React.FC<TabProps> = ({
   isLeftFocused = true,
   leftText,
   rightText,
+  onClick,
   ...props
 }) => {
   return (
@@ -56,10 +58,20 @@ const Tab: React.FC<TabProps> = ({
       margin={margin}
       padding={padding}
     >
-      <TabButton isLeft={isLeft} isLeftFocused={isLeftFocused}>
+      <TabButton
+        onClick={onClick}
+        isLeft={isLeft}
+        isLeftFocused={isLeftFocused}
+        id="left"
+      >
         {leftText}
       </TabButton>
-      <TabButton isLeft={!isLeft} isLeftFocused={!isLeftFocused}>
+      <TabButton
+        onClick={onClick}
+        isLeft={!isLeft}
+        isLeftFocused={!isLeftFocused}
+        id="right"
+      >
         {rightText}
       </TabButton>
     </TabContainer>

--- a/src/components/domains/index.ts
+++ b/src/components/domains/index.ts
@@ -10,4 +10,5 @@ export { default as UserChangeForm } from './UserChangeForm';
 export { default as Success } from './Success';
 export { default as OverlapCheck } from './OverlapCheck';
 export { default as ProfileEdit } from './ProfileEdit';
+export { default as PasswordForm } from './PasswordForm';
 export * from './EventDetail/index';

--- a/src/contexts/UserContext/types.ts
+++ b/src/contexts/UserContext/types.ts
@@ -2,15 +2,22 @@ export interface Info {
   email: string;
   password: string;
   passwordCheck: string;
+  passwordConfirm: string;
   nickname: string;
   token: string;
 }
 
 export type User = Partial<Pick<Info, 'email' | 'token' | 'nickname'>>;
 export type LoginUserInfo = Required<Pick<Info, 'email' | 'password'>>;
-export type RegisterUserFormData = Required<Omit<Info, 'token'>>;
-export type RegisterUserInfo = Required<Omit<Info, 'passwordCheck' | 'token'>>;
-export type ErrorUserForm = Partial<Omit<Info, 'token'>>;
+export type RegisterUserFormData = Required<
+  Omit<Info, 'token' | 'passwordConfirm'>
+>;
+export type RegisterUserInfo = Required<
+  Omit<Info, 'passwordCheck' | 'token' | 'passwordConfirm'>
+>;
+export type ErrorUserForm = Partial<Omit<Info, 'token' | 'passwordConfirm'>>;
+export type ProfileUserInfo = Partial<Omit<Info, 'email' | 'token'>>;
+export type ErrorProfile = Partial<Omit<Info, 'email' | 'token'>>;
 
 export type Action =
   | { type: 'LOG_IN'; user: User }

--- a/src/utils/computed.ts
+++ b/src/utils/computed.ts
@@ -1,0 +1,5 @@
+import { css } from '@emotion/react';
+
+export const marginBottom = (size: number | string) => css`
+  margin-bottom: ${typeof size === 'number' ? `${size}px` : size};
+`;

--- a/src/utils/constantUser.ts
+++ b/src/utils/constantUser.ts
@@ -16,6 +16,7 @@ export const text = {
   },
   password: 'password',
   passwordCheck: 'passwordCheck',
+  passwordConfirm: '비밀번호가 틀립니다.',
   passwordInput: '비밀번호 형식을 확인해주세요.',
   passwordFail: '비밀번호를 확인해주세요.',
   passwordReg: /^[A-Za-z0-9]{6,12}$/,

--- a/src/utils/constantUser.ts
+++ b/src/utils/constantUser.ts
@@ -3,7 +3,7 @@ export const LOGOUT = 'LOG_OUT';
 export const REGISTER = 'REGISTER';
 export const TOKEN = 'token';
 export const text = {
-  default: '8자 이상 영어, 숫자, 기호를 입력해주세요.',
+  default: '6자 이상 영어 대소문자, 숫자를 입력해주세요.',
   fail: '이메일과 비밀번호를 확인해주세요.',
   email: 'email',
   emailReg: /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-Za-z0-9\-]+/, //eslint-disable-line
@@ -19,7 +19,7 @@ export const text = {
   passwordConfirm: '비밀번호가 틀립니다.',
   passwordInput: '비밀번호 형식을 확인해주세요.',
   passwordFail: '비밀번호를 확인해주세요.',
-  passwordReg: /^[A-Za-z0-9]{6,12}$/,
+  passwordReg: /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)[A-Za-z\d]{6,100}$/,
   nickname: 'nickname',
   nicknameInput: '닉네임을 확인해주세요.',
   nicknameFail: '닉네임을 확인해주세요.',


### PR DESCRIPTION
## 구현내용

https://user-images.githubusercontent.com/63578094/146667245-88095ac2-9fbb-4459-a60b-088870e73275.mov

## 상세구현내용

- [x] 비밀번호 확인이 가능한가 -> 가능 하지만 비밀번호 API가 안됨
- [x] 닉네임 확인이 가능한가 -> 가능
- [x] 비밀번호 기능 잘 작동한가 -> 비밀번호가 다르면 오류 메시지
- [x] 수정할 데이터를 잘 내보내는가 -> 비밀번호가 확인돼야 가능 그리고 nickname이 있다면 중복체크해야 보낼수 있게 만들었습니다. ninckname과 password 둘 중 없는 값을 보낼때는 백엔드분들이 undefined를 보내면 된다 해서 해당 사항을 따랐습니다.

## 앞으로 구현해야 될것
- Tab버튼을 바꿔도 썼던 글자가 있어야 되는 것

## 추가 구현
1. 닉네임 중복 기존의 닉네임 티모100이 있기 때문에 중복됨을 표시
<img width="326" alt="Screen Shot 2021-12-20 at 11 18 29 AM" src="https://user-images.githubusercontent.com/63578094/146702757-0dfe584c-27cc-41dd-8962-845a200961c5.png">
2. 중복이 아니라면 확인 표시
<img width="352" alt="Screen Shot 2021-12-20 at 11 18 40 AM" src="https://user-images.githubusercontent.com/63578094/146702811-c7aba827-2ff2-4b31-b392-8d708deeb001.png">
3. 비밀번호 정규식 적용(비밀번호 일치X, 정규식 일치 X일 때) 오류 메시지
<img width="336" alt="Screen Shot 2021-12-20 at 11 19 15 AM" src="https://user-images.githubusercontent.com/63578094/146702847-f89d5dda-685e-4bcf-bddb-8f6be4bec446.png">
4. formdata 전송
닉네임이 없을 때는 undefined
비밀번호가 없을 때는 undefined
비밀번호확인이 되어야 전송가능
만약 닉네임이 값이 있을 때는 중복체크가 완료되어야됨
<img width="1057" alt="Screen Shot 2021-12-20 at 11 19 04 AM" src="https://user-images.githubusercontent.com/63578094/146702948-8c4b04b8-431a-414e-8a4a-9c7872b33926.png">

