### PR TITLE
[TLVB-162] 가게 보기 정보 API 연동

### DIFF
--- a/src/axios/shop/showShopInfo.ts
+++ b/src/axios/shop/showShopInfo.ts
@@ -1,0 +1,9 @@
+import request from '@axios/index';
+import { ResType } from '@axios/types';
+
+const showShopInfo = async () => {
+  const res: ResType<any> = await request.get(`/markets`);
+  return res;
+};
+
+export default showShopInfo;

--- a/src/components/domains/ShopDetail/ShopCountInfo.tsx
+++ b/src/components/domains/ShopDetail/ShopCountInfo.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text } from '@components/atoms';
-import { Shop } from '@contexts/Shop/types';
+import { ShopInfo } from '@contexts/Shop/types';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import Common from '@styles/index';
@@ -17,7 +17,7 @@ const CountCSS = css`
   font-weight: bold;
 `;
 
-interface ShopCountInfoProps extends Partial<Shop> {
+interface ShopCountInfoProps extends Partial<ShopInfo> {
   [index: string]: any;
 }
 

--- a/src/components/domains/ShopDetail/ShopDetailHeader.tsx
+++ b/src/components/domains/ShopDetail/ShopDetailHeader.tsx
@@ -40,12 +40,10 @@ const ShopDetailHeader = ({
   description,
 }: ShopDetailHeaderProps) => {
   const [visible, setVisible] = useState(false);
-  const [shopDescription, setShopDescription] = useState(description);
   const descriptionRef = useRef<HTMLTextAreaElement>(null);
 
   const handleEdit = () => {
-    if (visible) setShopDescription(descriptionRef.current?.value);
-    // TODO: 추후 리팩토링할 예정입니다.
+    // TODO: 추후 리팩토링할 예정입니다. 수정 API연동예정
     // eslint-disable-next-line no-unused-expressions
     visible ? setVisible(false) : setVisible(true);
   };
@@ -59,11 +57,11 @@ const ShopDetailHeader = ({
         {visible ? (
           <DescriptionTextarea
             ref={descriptionRef}
-            defaultValue={shopDescription || ''}
+            defaultValue={description || ''}
           />
         ) : (
           <Text size="small" block fontStyle={{ overflow: 'hidden' }}>
-            {shopDescription || '가게소개가 없어요!'}
+            {description || '가게소개가 없어요!'}
           </Text>
         )}
         <EditButton onClick={handleEdit}>✏️</EditButton>

--- a/src/components/domains/ShopDetail/ShopDetailHeader.tsx
+++ b/src/components/domains/ShopDetail/ShopDetailHeader.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from 'react';
 import { HeaderText, Text } from '@components/atoms';
-import { Shop } from '@contexts/Shop/types';
+import { ShopInfo } from '@contexts/Shop/types';
 import styled from '@emotion/styled';
 import Common from '@styles/index';
 
@@ -31,7 +31,7 @@ const EditButton = styled.button`
   margin-left: auto;
 `;
 
-interface ShopDetailHeaderProps extends Partial<Shop> {
+interface ShopDetailHeaderProps extends Partial<ShopInfo> {
   [index: string]: any;
 }
 

--- a/src/contexts/Shop/actions.tsx
+++ b/src/contexts/Shop/actions.tsx
@@ -1,0 +1,22 @@
+import { Dispatch, useCallback } from 'react';
+import showShopInfo from '@axios/shop/showShopInfo';
+import { GET_SHOP_INFO } from './types';
+
+const useShopProvider = (dispatch: Dispatch<any>) => {
+  const getShopInfo = useCallback(async () => {
+    const res = await showShopInfo();
+    const shopInfo = await res.data.simpleMarkets.content[0];
+
+    dispatch({
+      type: GET_SHOP_INFO,
+    });
+
+    return shopInfo;
+  }, [dispatch]);
+
+  return {
+    getShopInfo,
+  };
+};
+
+export default useShopProvider;

--- a/src/contexts/Shop/index.tsx
+++ b/src/contexts/Shop/index.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, useMemo, useReducer } from 'react';
+import useShopProvider from './actions';
+import { ShopInfoData, ShopContextType } from './types';
+import { shopContextreducer } from './reducer';
+
+const initialState: ShopInfoData = {
+  marketId: '',
+  description: '',
+  eventCount: 0,
+  favoriteCount: 0,
+  reviewCount: 0,
+};
+
+export const ShopContext = createContext<ShopContextType>(initialState);
+
+export const ShopProvider = ({ children }: { children: React.ReactNode }) => {
+  const [state, dispatch] = useReducer(shopContextreducer, initialState);
+  const { getShopInfo } = useShopProvider(dispatch);
+
+  const value = useMemo(
+    () => ({
+      state,
+      getShopInfo,
+    }),
+    [state, getShopInfo]
+  );
+
+  return <ShopContext.Provider value={value}>{children}</ShopContext.Provider>;
+};

--- a/src/contexts/Shop/reducer.tsx
+++ b/src/contexts/Shop/reducer.tsx
@@ -1,0 +1,14 @@
+import { ShopInfoData, Action } from './types';
+
+export const shopContextreducer = (
+  state: ShopInfoData,
+  action: Action
+): ShopInfoData => {
+  switch (action.type) {
+    case 'GET_SHOP_INFO':
+      return state;
+
+    default:
+      return state;
+  }
+};

--- a/src/contexts/Shop/types.ts
+++ b/src/contexts/Shop/types.ts
@@ -12,6 +12,7 @@ interface PicturesType {
 }
 
 // TODO: 일단 marketId, expiredAt, maxParticipants은 string으로 하고 추후 수정
+// TODO: 네이밍 수정 예정
 export interface ShopEventInfo {
   name: string | null;
   marketId: string | null;
@@ -19,6 +20,14 @@ export interface ShopEventInfo {
   expiredAt: string | null;
   maxParticipants: string | null;
   pictures: PicturesType[] | [];
+}
+
+export interface ShopEvent {
+  name: string | null;
+  expiredAt: string | null;
+  marketName: string | null;
+  favoriteCount: number | null;
+  reviewCount: number | null;
 }
 
 export interface ShopContextType {

--- a/src/contexts/Shop/types.ts
+++ b/src/contexts/Shop/types.ts
@@ -1,15 +1,8 @@
-export interface Shop {
-  marketName: string | null;
+export interface ShopInfo {
+  marketId: string | null;
+  name: string | null;
   description: string | null;
   eventCount: number | null;
-  favoriteCount: number | null;
-  reviewCount: number | null;
-}
-
-export interface ShopEvent {
-  name: string | null;
-  expiredAt: string | null;
-  marketName: string | null;
   favoriteCount: number | null;
   reviewCount: number | null;
 }
@@ -28,5 +21,15 @@ export interface ShopEventInfo {
   pictures: PicturesType[] | [];
 }
 
-// export type EventCreateFormData = Partial<Omit<ShopEventInfo, 'pictures'>>;
+export interface ShopContextType {
+  [dispatchEvent: string]: any;
+}
+
 export type EventCreateFormData = Partial<ShopEventInfo>;
+
+// TODO: API에 name이 추가된 후 리팩토링할 예정
+export type ShopInfoData = Partial<Omit<ShopInfo, 'name'>>;
+
+export type Action = { type: 'GET_SHOP_INFO' };
+
+export const GET_SHOP_INFO = 'GET_SHOP_INFO';

--- a/src/contexts/index.tsx
+++ b/src/contexts/index.tsx
@@ -2,14 +2,17 @@ import React from 'react';
 import EventListProvider from '@contexts/event';
 import ReviewProvider from '@contexts/review';
 import { UserProvider } from '@contexts/UserContext';
-import { OwnerProvider } from './Owner';
+import { OwnerProvider } from '@contexts/Owner';
+import { ShopProvider } from '@contexts/Shop';
 
 const ContextProvider: React.FC<React.ReactNode> = ({ children }) => {
   return (
     <UserProvider>
       <EventListProvider>
         <ReviewProvider>
-          <OwnerProvider>{children}</OwnerProvider>
+          <OwnerProvider>
+            <ShopProvider>{children}</ShopProvider>
+          </OwnerProvider>
         </ReviewProvider>
       </EventListProvider>
     </UserProvider>

--- a/src/pages/shop/[shopId]/index.tsx
+++ b/src/pages/shop/[shopId]/index.tsx
@@ -1,50 +1,7 @@
-import { useRouter } from 'next/dist/client/router';
 import React from 'react';
-import { MainContainer } from '@components/atoms';
-import { Header } from '@components/domains/index';
-import {
-  ShopDetailHeader,
-  ShopCountInfo,
-  ShopAddEvent,
-  ShopEvents,
-} from '@components/domains/ShopDetail/index';
-import shopData from 'fixtures/shop';
-import shopEventData from 'fixtures/shopEvents';
-import styled from '@emotion/styled';
-
-const EventContentWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-`;
 
 const ShopDetailPage = () => {
-  const router = useRouter();
-  const { shopId } = router.query;
-
-  // TODO: shopId에 대한 처리할 예정
-  /* eslint-disable no-console */
-  console.log(shopId);
-
-  const { marketName, description, eventCount, favoriteCount, reviewCount } =
-    shopData;
-
-  return (
-    <MainContainer>
-      <Header />
-      <ShopDetailHeader marketName={marketName} description={description} />
-      <EventContentWrapper>
-        <ShopCountInfo
-          eventCount={Number(eventCount)}
-          favoriteCount={Number(favoriteCount)}
-          reviewCount={Number(reviewCount)}
-        />
-        <ShopAddEvent />
-        <ShopEvents events={shopEventData} />
-      </EventContentWrapper>
-    </MainContainer>
-  );
+  return <div>가게 상세 페이지</div>;
 };
 
 export default ShopDetailPage;

--- a/src/pages/shop/index.tsx
+++ b/src/pages/shop/index.tsx
@@ -1,0 +1,61 @@
+// import { useRouter } from 'next/dist/client/router';
+import React, { useContext, useEffect, useState } from 'react';
+import { MainContainer } from '@components/atoms';
+import { Header } from '@components/domains/index';
+import {
+  ShopDetailHeader,
+  ShopCountInfo,
+  ShopAddEvent,
+  ShopEvents,
+} from '@components/domains/ShopDetail/index';
+import shopData from 'fixtures/shop';
+import shopEventData from 'fixtures/shopEvents';
+import styled from '@emotion/styled';
+import { ShopContext } from '@contexts/Shop';
+import { ShopInfoData } from '@contexts/Shop/types';
+
+const EventContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
+const initialState: ShopInfoData = {
+  marketId: '',
+  description: '',
+  eventCount: 0,
+  favoriteCount: 0,
+  reviewCount: 0,
+};
+
+const ShopDetailPage = () => {
+  const { getShopInfo } = useContext(ShopContext);
+  const [shopInfo, setShopInfo] = useState(initialState);
+
+  useEffect(() => {
+    getShopInfo().then((data: ShopInfoData) => {
+      setShopInfo(data);
+    });
+  }, [getShopInfo]);
+
+  const { marketName } = shopData;
+  const { description, eventCount, favoriteCount, reviewCount } = shopInfo;
+  return (
+    <MainContainer>
+      <Header />
+      <ShopDetailHeader marketName={marketName} description={description} />
+      <EventContentWrapper>
+        <ShopCountInfo
+          eventCount={Number(eventCount)}
+          favoriteCount={Number(favoriteCount)}
+          reviewCount={Number(reviewCount)}
+        />
+        <ShopAddEvent />
+        <ShopEvents events={shopEventData} />
+      </EventContentWrapper>
+    </MainContainer>
+  );
+};
+
+export default ShopDetailPage;


### PR DESCRIPTION
## 구현사항
* 가게 보기 정보 일부 API 연동
- [x] 가게 설명 (description) 가져오기 GET 
- [x] 이벤트 진행 수(eventCount), 받은 좋아요 수(favoriteCount), 받은 리뷰 수(reviewCount) GET

![image](https://user-images.githubusercontent.com/71805803/146678681-3b11ee38-9986-4bbd-89d6-05eb25721840.png)

![image](https://user-images.githubusercontent.com/71805803/146678605-e4f785a8-d9fd-449c-88b4-1e16ed815f88.png)

## 구현 예정
- [x] 가게 설명 수정 API 구현 진행 중 (백엔드) -> 구현 완료 후 연동할 예정
- [x] 이벤트 카드는 이벤트 생성 API연동 후 진행 예정
- [x] 가게이름(name) API 추가 진행 중 (백엔드) -> 수정 완료 후 연동할 예정

## 참고사항
* 현재 가게이름(name)을 받아올 수 없어 오비맥주 광진점으로 default value로 지정되어있습니다.