### PR TITLE
[TLVB-185] 가게 설명 수정 API 연동

### DIFF
--- a/src/axios/shop/updateShopInfo.ts
+++ b/src/axios/shop/updateShopInfo.ts
@@ -1,0 +1,13 @@
+import request from '@axios/index';
+import { ResType } from '@axios/types';
+
+const updateShopInfo = async (marketId: number, description: string) => {
+  const res: ResType<any> = await request.patch(
+    `/markets/${marketId}`,
+    description
+  );
+
+  return res;
+};
+
+export default updateShopInfo;

--- a/src/components/domains/ShopDetail/ShopDetailHeader.tsx
+++ b/src/components/domains/ShopDetail/ShopDetailHeader.tsx
@@ -1,8 +1,9 @@
-import React, { useRef, useState } from 'react';
+import React, { useContext, useRef, useState } from 'react';
 import { HeaderText, Text } from '@components/atoms';
 import { ShopInfo } from '@contexts/Shop/types';
 import styled from '@emotion/styled';
 import Common from '@styles/index';
+import { ShopContext } from '@contexts/Shop/index';
 
 const ShopDetailHeaderWrapper = styled.div`
   display: flex;
@@ -36,14 +37,25 @@ interface ShopDetailHeaderProps extends Partial<ShopInfo> {
 }
 
 const ShopDetailHeader = ({
+  marketId,
   marketName,
   description,
 }: ShopDetailHeaderProps) => {
   const [visible, setVisible] = useState(false);
+  const [updatedDescription, setUpdatedDescription] = useState(description);
   const descriptionRef = useRef<HTMLTextAreaElement>(null);
 
-  const handleEdit = () => {
-    // TODO: 추후 리팩토링할 예정입니다. 수정 API연동예정
+  const { putShopInfo } = useContext(ShopContext);
+
+  const handleEdit = async () => {
+    if (visible) {
+      const fetchedDescription =
+        descriptionRef.current?.value || '가게 소개가 없어요!';
+      setUpdatedDescription(fetchedDescription);
+      await putShopInfo(marketId, {
+        description: fetchedDescription,
+      });
+    }
     // eslint-disable-next-line no-unused-expressions
     visible ? setVisible(false) : setVisible(true);
   };
@@ -57,11 +69,11 @@ const ShopDetailHeader = ({
         {visible ? (
           <DescriptionTextarea
             ref={descriptionRef}
-            defaultValue={description || ''}
+            defaultValue={updatedDescription || description?.toString()}
           />
         ) : (
           <Text size="small" block fontStyle={{ overflow: 'hidden' }}>
-            {description || '가게소개가 없어요!'}
+            {updatedDescription || description}
           </Text>
         )}
         <EditButton onClick={handleEdit}>✏️</EditButton>

--- a/src/contexts/Shop/actions.tsx
+++ b/src/contexts/Shop/actions.tsx
@@ -1,8 +1,10 @@
 import { Dispatch, useCallback } from 'react';
 import showShopInfo from '@axios/shop/showShopInfo';
+import updateShopInfo from '@axios/shop/updateShopInfo';
 import postEventInfo from '@axios/event/createEvent';
 import {
   GET_SHOP_INFO,
+  PUT_SHOP_INFO,
   POST_EVENT_INFO,
   CHANGE_EVENT_CONTENT,
   EventCreateFormData,
@@ -18,6 +20,17 @@ const useShopProvider = (dispatch: Dispatch<any>) => {
 
     return res.data;
   }, [dispatch]);
+
+  const putShopInfo = useCallback(
+    async (marketId, description) => {
+      await updateShopInfo(marketId, description);
+
+      dispatch({
+        type: PUT_SHOP_INFO,
+      });
+    },
+    [dispatch]
+  );
 
   // TODO: 추후에 삭제될 예정입니다.
   const dispatchChangeEventContent = useCallback(
@@ -50,6 +63,7 @@ const useShopProvider = (dispatch: Dispatch<any>) => {
 
   return {
     getShopInfo,
+    putShopInfo,
     dispatchChangeEventContent,
     createShopEvent,
   };

--- a/src/contexts/Shop/index.tsx
+++ b/src/contexts/Shop/index.tsx
@@ -17,17 +17,28 @@ export const ShopContext = createContext<ShopContextType>(initialState);
 export const ShopProvider = ({ children }: { children: React.ReactNode }) => {
   const [state, dispatch] = useReducer(shopContextreducer, initialState);
 
-  const { getShopInfo, createShopEvent, dispatchChangeEventContent } =
-    useShopProvider(dispatch);
+  const {
+    getShopInfo,
+    putShopInfo,
+    createShopEvent,
+    dispatchChangeEventContent,
+  } = useShopProvider(dispatch);
 
   const value = useMemo(
     () => ({
       state,
       getShopInfo,
+      putShopInfo,
       createShopEvent,
       dispatchChangeEventContent,
     }),
-    [state, getShopInfo, createShopEvent, dispatchChangeEventContent]
+    [
+      state,
+      getShopInfo,
+      putShopInfo,
+      createShopEvent,
+      dispatchChangeEventContent,
+    ]
   );
 
   return <ShopContext.Provider value={value}>{children}</ShopContext.Provider>;

--- a/src/contexts/Shop/reducer.tsx
+++ b/src/contexts/Shop/reducer.tsx
@@ -7,6 +7,8 @@ export const shopContextreducer = (
   switch (action.type) {
     case 'GET_SHOP_INFO':
       return state;
+    case 'PUT_SHOP_INFO':
+      return state;
     case 'POST_EVENT_INFO':
       return state;
     case 'EVENT/CHANGE_CONTENT': {

--- a/src/contexts/Shop/types.ts
+++ b/src/contexts/Shop/types.ts
@@ -39,6 +39,7 @@ export type ShopInfoData = Partial<ShopInfo>;
 
 export type Action =
   | { type: 'GET_SHOP_INFO' }
+  | { type: 'PUT_SHOP_INFO' }
   | { type: 'POST_EVENT_INFO' }
   | {
       type: 'EVENT/CHANGE_CONTENT';
@@ -46,5 +47,6 @@ export type Action =
     };
 
 export const GET_SHOP_INFO = 'GET_SHOP_INFO';
+export const PUT_SHOP_INFO = 'PUT_SHOP_INFO';
 export const POST_EVENT_INFO = 'POST_EVENT_INFO';
 export const CHANGE_EVENT_CONTENT = 'EVENT/CHANGE_CONTENT';

--- a/src/pages/shop/index.tsx
+++ b/src/pages/shop/index.tsx
@@ -1,4 +1,3 @@
-// import { useRouter } from 'next/dist/client/router';
 import React, { useContext, useEffect, useState } from 'react';
 import { MainContainer } from '@components/atoms';
 import { Header } from '@components/domains/index';
@@ -39,11 +38,16 @@ const ShopDetailPage = () => {
     });
   }, [getShopInfo]);
 
-  const { name, description, eventCount, likeCount, reviewCount } = shopInfo;
+  const { marketId, name, description, eventCount, likeCount, reviewCount } =
+    shopInfo;
   return (
     <MainContainer>
       <Header />
-      <ShopDetailHeader marketName={name} description={description} />
+      <ShopDetailHeader
+        marketId={marketId}
+        marketName={name}
+        description={description}
+      />
       <EventContentWrapper>
         <ShopCountInfo
           eventCount={Number(eventCount)}


### PR DESCRIPTION
## 구현사항
* 가게 설명 수정 API 연동
![edit_shop_description](https://user-images.githubusercontent.com/71805803/146906606-3256f979-f9fc-40b7-86f5-eb0d7c700d1b.gif)

## 참고사항
* 직관적 업데이트 포함하여 수정을 완료하였습니다.
* marketId, description은 나중에 context/type에 맞게 리팩토링할 예정입니다.