### PR TITLE
[TLVB-196] 가게 이벤트 목록 조회 API 연동

### DIFF
--- a/src/axios/shop/showShopEvents.ts
+++ b/src/axios/shop/showShopEvents.ts
@@ -1,0 +1,9 @@
+import request from '@axios/index';
+import { ResType } from '@axios/types';
+
+const showShopEvents = async (marketId: number) => {
+  const res: ResType<any> = await request.get(`/markets/${marketId}/events`);
+  return res;
+};
+
+export default showShopEvents;

--- a/src/components/domains/ShopDetail/ShopEvents.tsx
+++ b/src/components/domains/ShopDetail/ShopEvents.tsx
@@ -1,23 +1,37 @@
-import React from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { CardList } from '@components/atoms';
 import { EventCard } from '@components/domains';
 import { ShopEvent } from '@contexts/Shop/types';
+import { ShopContext } from '@contexts/Shop';
 
 interface ShopEventsProps extends Partial<ShopEvent> {
   [index: string]: any;
 }
 
 // TODO: 각 이벤트 카드에 대한 라우팅 처리할 예정
-const handleClick = () => {};
+// const handleClick = () => {};
 
-const ShopEvents = ({ events }: ShopEventsProps) => {
+const ShopEvents = ({ marketId }: ShopEventsProps) => {
+  const { getShopEvents } = useContext(ShopContext);
+
+  const [eventInfo, setEventInfo] = useState([]);
+
+  const handleClick = () => {};
+  useEffect(() => {
+    if (marketId) {
+      getShopEvents(marketId).then((data: any) => {
+        setEventInfo(data);
+      });
+    }
+  }, [getShopEvents, marketId]);
+
   const defaultData = {
-    isLike: true,
+    like: true,
   };
 
   return (
     <CardList flexType="column" padding={0} margin="10px 0 0 0">
-      {events.map((event: any, index: number) => (
+      {eventInfo.map((event: any, index: number) => (
         <EventCard
           onClick={() => handleClick()}
           key={`${`${event}${index}`}`}

--- a/src/contexts/Shop/actions.tsx
+++ b/src/contexts/Shop/actions.tsx
@@ -66,7 +66,7 @@ const useShopProvider = (dispatch: Dispatch<any>) => {
   const getShopEvents = useCallback(
     async (marketId: number) => {
       const res = await showShopEvents(marketId);
-      // console.log('actions: ', res.data.events.content);
+
       dispatch({
         type: GET_SHOP_EVENTS,
       });

--- a/src/contexts/Shop/actions.tsx
+++ b/src/contexts/Shop/actions.tsx
@@ -1,11 +1,13 @@
 import { Dispatch, useCallback } from 'react';
 import showShopInfo from '@axios/shop/showShopInfo';
 import updateShopInfo from '@axios/shop/updateShopInfo';
+import showShopEvents from '@axios/shop/showShopEvents';
 import postEventInfo from '@axios/event/createEvent';
 import {
   GET_SHOP_INFO,
   PUT_SHOP_INFO,
   POST_EVENT_INFO,
+  GET_SHOP_EVENTS,
   CHANGE_EVENT_CONTENT,
   EventCreateFormData,
 } from './types';
@@ -61,11 +63,25 @@ const useShopProvider = (dispatch: Dispatch<any>) => {
     [dispatch]
   );
 
+  const getShopEvents = useCallback(
+    async (marketId: number) => {
+      const res = await showShopEvents(marketId);
+      // console.log('actions: ', res.data.events.content);
+      dispatch({
+        type: GET_SHOP_EVENTS,
+      });
+
+      return res.data.events.content;
+    },
+    [dispatch]
+  );
+
   return {
     getShopInfo,
     putShopInfo,
     dispatchChangeEventContent,
     createShopEvent,
+    getShopEvents,
   };
 };
 

--- a/src/contexts/Shop/index.tsx
+++ b/src/contexts/Shop/index.tsx
@@ -21,6 +21,7 @@ export const ShopProvider = ({ children }: { children: React.ReactNode }) => {
     getShopInfo,
     putShopInfo,
     createShopEvent,
+    getShopEvents,
     dispatchChangeEventContent,
   } = useShopProvider(dispatch);
 
@@ -30,6 +31,7 @@ export const ShopProvider = ({ children }: { children: React.ReactNode }) => {
       getShopInfo,
       putShopInfo,
       createShopEvent,
+      getShopEvents,
       dispatchChangeEventContent,
     }),
     [
@@ -37,6 +39,7 @@ export const ShopProvider = ({ children }: { children: React.ReactNode }) => {
       getShopInfo,
       putShopInfo,
       createShopEvent,
+      getShopEvents,
       dispatchChangeEventContent,
     ]
   );

--- a/src/contexts/Shop/reducer.tsx
+++ b/src/contexts/Shop/reducer.tsx
@@ -11,6 +11,8 @@ export const shopContextreducer = (
       return state;
     case 'POST_EVENT_INFO':
       return state;
+    case 'GET_SHOP_EVENTS':
+      return state;
     case 'EVENT/CHANGE_CONTENT': {
       const { name, value } = action.payload;
       return {

--- a/src/contexts/Shop/types.ts
+++ b/src/contexts/Shop/types.ts
@@ -23,8 +23,9 @@ export interface ShopEventInfo {
 }
 
 export interface ShopEvent {
-  name: string | null;
+  eventId: number | null;
   expiredAt: string | null;
+  name: string | null;
   marketName: string | null;
   likeCount: number | null;
   reviewCount: number | null;
@@ -41,6 +42,7 @@ export type Action =
   | { type: 'GET_SHOP_INFO' }
   | { type: 'PUT_SHOP_INFO' }
   | { type: 'POST_EVENT_INFO' }
+  | { type: 'GET_SHOP_EVENTS' }
   | {
       type: 'EVENT/CHANGE_CONTENT';
       payload: { name: string; value: File | string };
@@ -50,3 +52,4 @@ export const GET_SHOP_INFO = 'GET_SHOP_INFO';
 export const PUT_SHOP_INFO = 'PUT_SHOP_INFO';
 export const POST_EVENT_INFO = 'POST_EVENT_INFO';
 export const CHANGE_EVENT_CONTENT = 'EVENT/CHANGE_CONTENT';
+export const GET_SHOP_EVENTS = 'GET_SHOP_EVENTS';

--- a/src/pages/shop/index.tsx
+++ b/src/pages/shop/index.tsx
@@ -7,7 +7,6 @@ import {
   ShopAddEvent,
   ShopEvents,
 } from '@components/domains/ShopDetail/index';
-import shopEventData from 'fixtures/shopEvents';
 import styled from '@emotion/styled';
 import { ShopContext } from '@contexts/Shop';
 import { ShopInfoData } from '@contexts/Shop/types';
@@ -55,7 +54,7 @@ const ShopDetailPage = () => {
           reviewCount={Number(reviewCount)}
         />
         <ShopAddEvent />
-        <ShopEvents events={shopEventData} />
+        <ShopEvents marketId={marketId} />
       </EventContentWrapper>
     </MainContainer>
   );


### PR DESCRIPTION
## 구현사항
* 해당 가게 이벤트 목록 조회 API 연동
![list_shop_events](https://user-images.githubusercontent.com/71805803/146948573-e1f4852d-b3de-4a14-9c67-e84b00c6f739.gif)


## 참고사항
* memory leak에 대한 warning이 떠서 추후에 수정할 예정입니다.