### PR TITLE
[TLVB-203] 메인 페이지, 이벤트 상세 조회 페이지 Memory leak issue 해결

### DIFF
--- a/src/hooks/useLoginCheck.ts
+++ b/src/hooks/useLoginCheck.ts
@@ -11,6 +11,10 @@ const useLoginCheck = () => {
   const router = useRouter();
 
   useEffect(() => {
+    return () => setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
     setIsFirst(() => false);
     if (window) {
       setToken(localStorage.getItem('token'));

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -114,6 +114,12 @@ const MainPage: NextPage = () => {
     sortState,
     sortTypeState,
   ]);
+  useEffect(() => {
+    return () => {
+      setUserAddress(() => null);
+      setModalVisible(() => false);
+    };
+  }, []);
 
   const buttonNames = {
     createdAt: '최신 순',


### PR DESCRIPTION
# PR 설명
현재 메인 페이지, 이벤트 상세 조회 페이지에서 발생하던 메모리 누수 이슈를 해결하였습니다.

# 원인
메인 페이지, 이벤트 상세 조회 페이지에서는 계속해서 `token`을 가져옴으로써 
1. 현재 유효한 토큰인지,
2. 이 유저는 어떤 유저인지를 판단하고 있으며, 
3. 이를 계속해서 조회하지 않도록 로딩을 걸어 처리하고 있습니다.

이때 페이지를 이동할 때, `router`로 인해 `loading`이 변경이 되고, 따라서 누수가 될 상황이 존재했습니다.

# 해결
`useEffect`를 통해 언마운트될 때에는 반드시 `setIsLoading`의 상태가 `false`가 되도록 변경하여 해결하였습니다.