### PR TITLE
[TLVB-205] 사업자등록 validation 에러 수정

### DIFF
--- a/src/components/domains/UserChangeForm.tsx
+++ b/src/components/domains/UserChangeForm.tsx
@@ -71,11 +71,15 @@ const UserChangeForm = () => {
       if (!name) {
         setErrorName(Constants.ERROR_MSG.marketNameInput);
         newErrors.address = 'Y';
+      } else {
+        setErrorName('');
       }
       if (description) {
         if (description.length > 200) {
           setErrorDescription(Constants.ERROR_MSG.marketDescriptionFormat);
           newErrors.description = 'Y';
+        } else {
+          setErrorDescription('');
         }
       } else {
         setErrorDescription(Constants.ERROR_MSG.marketDescriptionInput);
@@ -85,7 +89,10 @@ const UserChangeForm = () => {
       if (!address) {
         setErrorAddress(Constants.ERROR_MSG.marketAddressInput);
         newErrors.address = 'Y';
+      } else {
+        setErrorAddress('');
       }
+
       if (Object.keys(newErrors).length === 0) {
         setErrorName('');
         setErrorDescription('');


### PR DESCRIPTION
## 구현사항
* 테스트하다가 사업자등록에 다음과 같이 올바르게 수정하고 등록버튼을 눌러도 에러메시지가 사라지지 않았습니다.
<img width="326" alt="error_validation1" src="https://user-images.githubusercontent.com/71805803/146985546-01eefa59-edde-4ad8-bd5b-18021c29d651.PNG">

* 다음과 같이 각 항목에 대해 올바른 형태로 입력하면 에러메시지가 사라지게 초기화하였습니다.
<img width="303" alt="error_validation2" src="https://user-images.githubusercontent.com/71805803/146985604-c5691c11-29cb-4438-81b7-fab120809747.PNG">
