### PR TITLE
[TLVB-200] 메인 페이지 무한스크롤 구현

### DIFF
--- a/src/contexts/event/actions.ts
+++ b/src/contexts/event/actions.ts
@@ -30,11 +30,12 @@ const useEventProvider = (dispatch: Dispatch<any>) => {
       dispatchLoading();
       const res = await getEventList({ location, sort, page, size });
       const events: typeof res.data.events = res.data?.events ?? null;
+
       dispatch({
         type: GET_EVENTLIST,
         payload: {
           eventList: events?.content || [],
-          eventListOption: {
+          eventListOptions: {
             totalPages: events?.totalPages ?? null,
             totalElements: events?.totalElements ?? null,
             last: events?.last ?? null,

--- a/src/contexts/event/reducer.ts
+++ b/src/contexts/event/reducer.ts
@@ -23,17 +23,18 @@ const eventReducer = (state: InitialStateType, action: Action) => {
       };
     }
     case GET_EVENTLIST: {
-      const { eventList } = action.payload;
+      const { eventList, eventListOptions } = action.payload;
       return {
         ...state,
         isLoading: false,
-        eventList,
+        eventList: [...state.eventList, ...eventList],
+        eventListOptions,
       };
     }
     case INITIALIZE_EVENTLIST: {
       return {
         ...state,
-        initialState,
+        ...initialState,
       };
     }
     case GET_EVENT: {

--- a/src/contexts/event/types.ts
+++ b/src/contexts/event/types.ts
@@ -76,7 +76,11 @@ export type Action =
     }
   | {
       type: 'EVENTLIST/GET';
-      payload: { eventList: EventListType; eventError: ErrorType };
+      payload: {
+        eventList: EventListType;
+        eventListOptions: EventListOptions;
+        eventError: ErrorType;
+      };
     }
   | { type: 'EVENTLIST/INITIALIZE' }
   | {


### PR DESCRIPTION
# PR 설명
페이지 무한 스크롤을 구현하였습니다.

# 이슈
페이지 무한 스크롤 도중 리렌더링으로 인하여 스크롤 제어가 불가한 현상이 발생하였습니다.

# 원인
페이지를 리렌더링하면서, 새롭게 `loading`이 재정의됨 인해 컴포넌트가 삼항 연산자로 인하여 발생한 문제였습니다.

[이슈 링크](https://stackoverflow.com/questions/63096118/react-redux-infinite-scroll-re-rendering-whole-list)

# 시연 영상
![2](https://user-images.githubusercontent.com/78713176/146999735-ae08256d-59b1-4792-81e8-2a3fba2b98c7.gif)
