### PR TITLE
[TLVB-221] 유저 정보 조회 페이지 구현

### DIFF
--- a/src/axios/members.ts
+++ b/src/axios/members.ts
@@ -1,5 +1,6 @@
 import request from '@axios/index';
 import { ResType } from '@axios/types';
+import { ReviewListResponse } from '@contexts/userHistory/types';
 
 export const getFavoriteShops = async (memberId: string) => {
   const res: ResType<any> = await request.get(
@@ -21,6 +22,8 @@ export const getJoinedEvents = async (memberId: string) => {
 };
 
 export const getReviews = async (memberId: string) => {
-  const res: ResType<any> = await request.get(`/members/${memberId}/reviews`);
+  const res: ResType<ReviewListResponse | null> = await request.get(
+    `/members/${memberId}/reviews`
+  );
   return res;
 };

--- a/src/axios/members.ts
+++ b/src/axios/members.ts
@@ -20,7 +20,7 @@ export const getJoinedEvents = async (memberId: string) => {
   return res;
 };
 
-export const getMyReview = async (memberId: string) => {
+export const getReviews = async (memberId: string) => {
   const res: ResType<any> = await request.get(`/members/${memberId}/reviews`);
   return res;
 };

--- a/src/components/atoms/CardContainer.tsx
+++ b/src/components/atoms/CardContainer.tsx
@@ -57,6 +57,7 @@ const StyledDefaultCardContainer = styled('article')<StyledDefaultCardProps>`
 `;
 
 const StyledBoxCardContainer = styled('article')<CardStyleProps>`
+  position: relative;
   box-sizing: border-box;
   height: 170px;
   background: ${styles.colors.background};

--- a/src/components/atoms/Text.tsx
+++ b/src/components/atoms/Text.tsx
@@ -7,6 +7,7 @@ type sizeTypes = 'micro' | 'small' | 'medium' | 'large';
 
 export interface TextProps {
   children: string | ReactNode;
+  bold?: boolean;
   size?: string | number;
   color?: string;
   underline?: boolean;
@@ -15,14 +16,20 @@ export interface TextProps {
   [prop: string]: any;
 }
 
-const StyledText = styled.div`
+const StyledText = styled.div<TextProps>`
   ${({ size }: TextProps) => css`
     ${typeof size === 'string' && Common.fontStyle[size as sizeTypes]()}
   `}
+  ${({ bold }) =>
+    bold &&
+    css`
+      font-weight: 700;
+    `}
 `;
 
 const Text = ({
   children,
+  bold,
   size,
   color,
   underline,
@@ -43,6 +50,7 @@ const Text = ({
     <StyledText
       as={Tag}
       size={size}
+      bold={bold}
       style={{ ...props.fontStyle, ...fontStyle }}
       {...props}
     >

--- a/src/components/domains/ReviewCard.tsx
+++ b/src/components/domains/ReviewCard.tsx
@@ -35,6 +35,12 @@ const CardFooterBox = styled.div`
   ${TextMarginBottomCSS}
 `;
 
+const MarketNameCSS = css`
+  position: absolute;
+  bottom: 10px;
+  ${TextMarginBottomCSS}
+`;
+
 const StyledDescriptionBox = styled.div`
   display: flex;
   flex-direction: column;
@@ -42,15 +48,15 @@ const StyledDescriptionBox = styled.div`
   width: 100%;
 `;
 
-export interface reviewDataTypes {
+export interface ReviewData extends Partial<Review> {
   marketName?: string;
-  pictureUrl: string | undefined;
-  description: string;
+  pictureUrl?: string | undefined;
+  description?: string;
   [prop: string]: any;
 }
 interface ReviewCardProps {
   cardType: 'default' | 'box';
-  reviewData: Review;
+  reviewData: ReviewData;
   marginWidth?: string | number;
   marginHeight?: string | number;
   [prop: string]: any;
@@ -78,12 +84,22 @@ const ReviewCard = ({
           <Text block size="small" css={DescriptionMarginBottomCSS}>
             {reviewData.description}
           </Text>
-          <Text block size="micro">
-            {reviewData.createdAt}
-          </Text>
-          <Text block size="micro" css={TextMarginBottomCSS}>
-            {`by ${reviewData.memberNickname}`}
-          </Text>
+          {/* TODO: 추후 해당 옵션값을 넣어줄 것을 백엔드 측에 요구한다. */}
+          {reviewData.createdAt && (
+            <Text block size="micro">
+              {reviewData.createdAt}
+            </Text>
+          )}
+          {reviewData.memberNickname && (
+            <Text block size="micro" css={TextMarginBottomCSS}>
+              {`by ${reviewData.memberNickname}`}
+            </Text>
+          )}
+          {reviewData.marketName && (
+            <Text block size="micro" css={MarketNameCSS}>
+              {`To. ${reviewData.marketName}`}
+            </Text>
+          )}
         </>
       ) : (
         <DefaultTypeReviewInner>

--- a/src/components/domains/ReviewCard.tsx
+++ b/src/components/domains/ReviewCard.tsx
@@ -51,7 +51,6 @@ const StyledDescriptionBox = styled.div`
 export interface ReviewData extends Partial<Review> {
   marketName?: string;
   pictureUrl?: string | undefined;
-  description?: string;
   [prop: string]: any;
 }
 interface ReviewCardProps {

--- a/src/components/domains/StateCounter.tsx
+++ b/src/components/domains/StateCounter.tsx
@@ -1,5 +1,7 @@
 import { Text } from '@components/atoms';
 import styled from '@emotion/styled';
+import styles from '@styles/index';
+import { marginTop } from '@utils/computed';
 import React from 'react';
 
 interface StateCounterProps {
@@ -14,8 +16,12 @@ const StyledStateCounter = styled.div`
 const StateCounter = ({ name, count }: StateCounterProps) => {
   return (
     <StyledStateCounter>
-      <Text size={24}>{name}</Text>
-      <Text size={14}>{count}</Text>
+      <Text size={24} bold color={styles.colors.point}>
+        {count}
+      </Text>
+      <Text size={14} color={styles.colors.primary} css={marginTop(16)}>
+        {name}
+      </Text>
     </StyledStateCounter>
   );
 };

--- a/src/components/domains/StateCounter.tsx
+++ b/src/components/domains/StateCounter.tsx
@@ -1,0 +1,23 @@
+import { Text } from '@components/atoms';
+import styled from '@emotion/styled';
+import React from 'react';
+
+interface StateCounterProps {
+  name: string;
+  count: number;
+}
+const StyledStateCounter = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+const StateCounter = ({ name, count }: StateCounterProps) => {
+  return (
+    <StyledStateCounter>
+      <Text size={24}>{name}</Text>
+      <Text size={14}>{count}</Text>
+    </StyledStateCounter>
+  );
+};
+
+export default StateCounter;

--- a/src/contexts/index.tsx
+++ b/src/contexts/index.tsx
@@ -4,17 +4,20 @@ import ReviewProvider from '@contexts/review';
 import { UserProvider } from '@contexts/UserContext';
 import { OwnerProvider } from '@contexts/Owner';
 import { ShopProvider } from '@contexts/Shop';
+import UserHistoryProvider from '@contexts/userHistory';
 
 const ContextProvider: React.FC<React.ReactNode> = ({ children }) => {
   return (
     <UserProvider>
-      <EventListProvider>
-        <ReviewProvider>
-          <OwnerProvider>
-            <ShopProvider>{children}</ShopProvider>
-          </OwnerProvider>
-        </ReviewProvider>
-      </EventListProvider>
+      <UserHistoryProvider>
+        <EventListProvider>
+          <ReviewProvider>
+            <OwnerProvider>
+              <ShopProvider>{children}</ShopProvider>
+            </OwnerProvider>
+          </ReviewProvider>
+        </EventListProvider>
+      </UserHistoryProvider>
     </UserProvider>
   );
 };

--- a/src/contexts/userHistory/actions.ts
+++ b/src/contexts/userHistory/actions.ts
@@ -84,8 +84,8 @@ const useHistoryProvider = (dispatch: Dispatch<any>) => {
       dispatchLoading();
       const res = await getReviews(memberId);
       const { data, error } = res;
-      let { userReviewList } = initialState;
-      let { userReviewListOptions } = initialState;
+
+      let { userReviewList, userReviewListOptions } = initialState;
       if (data?.reviews?.content) {
         const { reviewerEventCount, reviewerReviewCount } = data;
         const { content, totalPages, totalElements, last } = data.reviews;
@@ -98,6 +98,7 @@ const useHistoryProvider = (dispatch: Dispatch<any>) => {
           reviewerReviewCount,
         };
       }
+
       dispatch({
         type: GET_USER_REVIEWS,
         payload: {

--- a/src/contexts/userHistory/actions.ts
+++ b/src/contexts/userHistory/actions.ts
@@ -88,8 +88,7 @@ const useHistoryProvider = (dispatch: Dispatch<any>) => {
       let { userReviewListOptions } = initialState;
       if (data?.reviews?.content) {
         const { reviewerEventCount, reviewerReviewCount } = data;
-        const { content, totalPages, totalElements, last } =
-          data.reviews.content;
+        const { content, totalPages, totalElements, last } = data.reviews;
         userReviewList = content;
         userReviewListOptions = {
           totalPages,

--- a/src/contexts/userHistory/actions.ts
+++ b/src/contexts/userHistory/actions.ts
@@ -12,6 +12,7 @@ import {
   GET_JOINED_EVENT,
   GET_LIKE_EVENT,
   GET_MY_REVIEW,
+  GET_USER_REVIEWS,
 } from './types';
 
 const useHistoryProvider = (dispatch: Dispatch<any>) => {
@@ -25,9 +26,10 @@ const useHistoryProvider = (dispatch: Dispatch<any>) => {
   }, [dispatch]);
 
   const dispatchFavoriteShops = useCallback(
-    async (membersId) => {
+    async (memberId) => {
+      if (!memberId) return;
       dispatchLoading();
-      const res = await getFavoriteShops(membersId);
+      const res = await getFavoriteShops(memberId);
       dispatch({
         type: GET_FAVORITE_SHOP,
         payload: { favoriteShopList: res.data, historyError: res.error },
@@ -37,9 +39,10 @@ const useHistoryProvider = (dispatch: Dispatch<any>) => {
   );
 
   const dispatchLikeEvents = useCallback(
-    async (membersId) => {
+    async (memberId) => {
+      if (!memberId) return;
       dispatchLoading();
-      const res = await getLikeEvents(membersId);
+      const res = await getLikeEvents(memberId);
       dispatch({
         type: GET_LIKE_EVENT,
         payload: { likeEventList: res.data, historyError: res.error },
@@ -49,9 +52,10 @@ const useHistoryProvider = (dispatch: Dispatch<any>) => {
   );
 
   const dispatchJoinedEvents = useCallback(
-    async (membersId) => {
+    async (memberId) => {
+      if (!memberId) return;
       dispatchLoading();
-      const res = await getJoinedEvents(membersId);
+      const res = await getJoinedEvents(memberId);
       dispatch({
         type: GET_JOINED_EVENT,
         payload: { joinedEventList: res.data, historyError: res.error },
@@ -60,13 +64,26 @@ const useHistoryProvider = (dispatch: Dispatch<any>) => {
     [dispatch, dispatchLoading]
   );
 
-  const dispatchMyReview = useCallback(
-    async (membersId) => {
+  const dispatchMyReviews = useCallback(
+    async (memberId) => {
+      if (!memberId) return;
       dispatchLoading();
-      const res = await getMyReview(membersId);
+      const res = await getMyReview(memberId);
       dispatch({
         type: GET_MY_REVIEW,
         payload: { myReviewList: res.data, historyError: res.error },
+      });
+    },
+    [dispatch, dispatchLoading]
+  );
+  const dispatchUserReviews = useCallback(
+    async (memberId) => {
+      if (!memberId) return;
+      dispatchLoading();
+      const res = await getMyReview(memberId);
+      dispatch({
+        type: GET_USER_REVIEWS,
+        payload: { userReviewList: res.data, historyError: res.error },
       });
     },
     [dispatch, dispatchLoading]
@@ -78,7 +95,8 @@ const useHistoryProvider = (dispatch: Dispatch<any>) => {
     dispatchFavoriteShops,
     dispatchLikeEvents,
     dispatchJoinedEvents,
-    dispatchMyReview,
+    dispatchMyReviews,
+    dispatchUserReviews,
   };
 };
 

--- a/src/contexts/userHistory/index.tsx
+++ b/src/contexts/userHistory/index.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useMemo, useReducer } from 'react';
 import {
+  ContextType,
   HistoryProviderProps,
   InitialStateType,
 } from '@contexts/userHistory/types';
@@ -13,14 +14,15 @@ export const initialState: InitialStateType = {
   favoriteShopList: [],
   likeEventList: [],
   myReviewList: [],
+  userReviewList: [],
   historyError: {
     code: null,
     message: null,
   },
 };
 
-const UserHistoryContext = createContext(initialState);
-export const useHistory = () => useContext(UserHistoryContext);
+const UserHistoryContext = createContext<ContextType>(initialState);
+export const useUserHistory = () => useContext(UserHistoryContext);
 
 const UserHistoryProvider = ({ children }: HistoryProviderProps) => {
   const [
@@ -30,6 +32,7 @@ const UserHistoryProvider = ({ children }: HistoryProviderProps) => {
       likeEventList,
       joinedEventList,
       myReviewList,
+      userReviewList,
       historyError,
     },
     dispatch,
@@ -40,7 +43,8 @@ const UserHistoryProvider = ({ children }: HistoryProviderProps) => {
     dispatchFavoriteShops,
     dispatchLikeEvents,
     dispatchJoinedEvents,
-    dispatchMyReview,
+    dispatchMyReviews,
+    dispatchUserReviews,
   } = useHistoryProvider(dispatch);
 
   const contextValue = useMemo(
@@ -50,12 +54,14 @@ const UserHistoryProvider = ({ children }: HistoryProviderProps) => {
       favoriteShopList,
       likeEventList,
       myReviewList,
+      userReviewList,
       historyError,
       initializeHistory,
       dispatchFavoriteShops,
       dispatchLikeEvents,
       dispatchJoinedEvents,
-      dispatchMyReview,
+      dispatchMyReviews,
+      dispatchUserReviews,
     }),
     [
       isLoading,
@@ -63,12 +69,14 @@ const UserHistoryProvider = ({ children }: HistoryProviderProps) => {
       favoriteShopList,
       likeEventList,
       myReviewList,
+      userReviewList,
       historyError,
       initializeHistory,
       dispatchFavoriteShops,
       dispatchLikeEvents,
       dispatchJoinedEvents,
-      dispatchMyReview,
+      dispatchMyReviews,
+      dispatchUserReviews,
     ]
   );
 

--- a/src/contexts/userHistory/index.tsx
+++ b/src/contexts/userHistory/index.tsx
@@ -4,8 +4,8 @@ import {
   HistoryProviderProps,
   InitialStateType,
 } from '@contexts/userHistory/types';
-import useHistoryProvider from './actions';
 /* eslint-disable import/no-cycle */
+import useHistoryProvider from './actions';
 import userHistoryReducer from './reducer';
 
 export const initialState: InitialStateType = {
@@ -19,6 +19,8 @@ export const initialState: InitialStateType = {
     last: null,
     totalPages: 0,
     totalElements: 0,
+    reviewerEventCount: 0,
+    reviewerReviewCount: 0,
   },
   historyError: {
     code: null,
@@ -38,6 +40,7 @@ const UserHistoryProvider = ({ children }: HistoryProviderProps) => {
       joinedEventList,
       myReviewList,
       userReviewList,
+      userReviewListOptions,
       historyError,
     },
     dispatch,
@@ -60,6 +63,7 @@ const UserHistoryProvider = ({ children }: HistoryProviderProps) => {
       likeEventList,
       myReviewList,
       userReviewList,
+      userReviewListOptions,
       historyError,
       initializeHistory,
       dispatchFavoriteShops,
@@ -75,6 +79,7 @@ const UserHistoryProvider = ({ children }: HistoryProviderProps) => {
       likeEventList,
       myReviewList,
       userReviewList,
+      userReviewListOptions,
       historyError,
       initializeHistory,
       dispatchFavoriteShops,

--- a/src/contexts/userHistory/index.tsx
+++ b/src/contexts/userHistory/index.tsx
@@ -1,8 +1,11 @@
 import { createContext, useContext, useMemo, useReducer } from 'react';
+import {
+  HistoryProviderProps,
+  InitialStateType,
+} from '@contexts/userHistory/types';
 import useHistoryProvider from './actions';
 /* eslint-disable import/no-cycle */
 import userHistoryReducer from './reducer';
-import { HistoryProviderProps, InitialStateType } from './types';
 
 export const initialState: InitialStateType = {
   isLoading: false,

--- a/src/contexts/userHistory/index.tsx
+++ b/src/contexts/userHistory/index.tsx
@@ -15,6 +15,11 @@ export const initialState: InitialStateType = {
   likeEventList: [],
   myReviewList: [],
   userReviewList: [],
+  userReviewListOptions: {
+    last: null,
+    totalPages: 0,
+    totalElements: 0,
+  },
   historyError: {
     code: null,
     message: null,

--- a/src/contexts/userHistory/reducer.ts
+++ b/src/contexts/userHistory/reducer.ts
@@ -6,6 +6,7 @@ import {
   GET_JOINED_EVENT,
   GET_LIKE_EVENT,
   GET_MY_REVIEW,
+  GET_USER_REVIEWS,
   HISTORY_LOADING,
   INITIALIZE_HISTORY,
   InitialStateType,
@@ -62,6 +63,15 @@ const userHistoryReducer = (state: InitialStateType, action: Action) => {
       return {
         ...state,
         myReviewList,
+        historyError,
+        isLoading: false,
+      };
+    }
+    case GET_USER_REVIEWS: {
+      const { userReviewList, historyError } = action.payload;
+      return {
+        ...state,
+        userReviewList,
         historyError,
         isLoading: false,
       };

--- a/src/contexts/userHistory/reducer.ts
+++ b/src/contexts/userHistory/reducer.ts
@@ -68,10 +68,12 @@ const userHistoryReducer = (state: InitialStateType, action: Action) => {
       };
     }
     case GET_USER_REVIEWS: {
-      const { userReviewList, historyError } = action.payload;
+      const { userReviewList, userReviewListOptions, historyError } =
+        action.payload;
       return {
         ...state,
         userReviewList,
+        userReviewListOptions,
         historyError,
         isLoading: false,
       };

--- a/src/contexts/userHistory/reducer.ts
+++ b/src/contexts/userHistory/reducer.ts
@@ -16,14 +16,14 @@ const userHistoryReducer = (state: InitialStateType, action: Action) => {
     case HISTORY_LOADING: {
       return {
         ...state,
-        isLaoding: true,
+        isLoading: true,
       };
     }
 
     case INITIALIZE_HISTORY: {
       return {
         ...state,
-        initialState,
+        ...initialState,
       };
     }
 
@@ -33,6 +33,7 @@ const userHistoryReducer = (state: InitialStateType, action: Action) => {
         ...state,
         favoriteShopList,
         historyError,
+        isLoading: false,
       };
     }
 
@@ -42,6 +43,7 @@ const userHistoryReducer = (state: InitialStateType, action: Action) => {
         ...state,
         likeEventList,
         historyError,
+        isLoading: false,
       };
     }
 
@@ -51,6 +53,7 @@ const userHistoryReducer = (state: InitialStateType, action: Action) => {
         ...state,
         joinedEventList,
         historyError,
+        isLoading: false,
       };
     }
 
@@ -60,6 +63,7 @@ const userHistoryReducer = (state: InitialStateType, action: Action) => {
         ...state,
         myReviewList,
         historyError,
+        isLoading: false,
       };
     }
     default: {

--- a/src/contexts/userHistory/types.ts
+++ b/src/contexts/userHistory/types.ts
@@ -42,6 +42,7 @@ export const GET_JOINED_EVENT = 'HISTORY/GET_JOINED_EVENT' as const;
 export const GET_FAVORITE_SHOP = 'HISTORY/GET_FAVORITE_SHOP' as const;
 export const GET_LIKE_EVENT = 'HISTORY/GET_LIKE_EVENT' as const;
 export const GET_MY_REVIEW = 'HISTORY/GET_MY_REVIEW' as const;
+export const GET_USER_REVIEWS = 'HISTORY/GET_USER_REVIEWS';
 
 export interface HistoryProviderProps {
   children: ReactNode;
@@ -53,7 +54,11 @@ export interface InitialStateType {
   likeEventList: Array<LikeEvent> | [];
   joinedEventList: Array<JoinedEvent> | [];
   myReviewList: Array<MyReview> | [];
+  userReviewList: Array<MyReview> | [];
   historyError: ErrorType;
+}
+export interface ContextType extends InitialStateType {
+  [dispatchEvent: string]: any;
 }
 
 export type Action =
@@ -74,4 +79,8 @@ export type Action =
   | {
       type: 'HISTORY/GET_MY_REVIEW';
       payload: { myReviewList: MyReview[]; historyError: ErrorType };
+    }
+  | {
+      type: 'HISTORY/GET_USER_REVIEWS';
+      payload: { userReviewList: MyReview[]; historyError: ErrorType };
     };

--- a/src/contexts/userHistory/types.ts
+++ b/src/contexts/userHistory/types.ts
@@ -1,6 +1,41 @@
 import { ErrorType } from '@axios/types';
 import { ReactNode } from 'react';
 
+interface ReviewerCount {
+  reviewerEventCount: number;
+  reviewerReviewCount: number;
+}
+export interface ReviewListResponse extends ReviewerCount {
+  reviews: {
+    content: Array<UserReview>;
+    pageable: {
+      sort: {
+        empty: boolean;
+        unsorted: boolean;
+        sorted: boolean;
+      };
+      offset: number;
+      pageNumber: number;
+      pageSize: number;
+      unpaged: boolean;
+      paged: boolean;
+    };
+    last: boolean;
+    totalPages: number;
+    totalElements: number;
+    size: number;
+    number: number;
+    sort: {
+      empty: boolean;
+      unsorted: boolean;
+      sorted: boolean;
+    };
+    first: boolean;
+    numberOfElements: number;
+    empty: boolean;
+  };
+}
+
 export interface FavoriteShop {
   marketId: number;
   name: string;
@@ -26,14 +61,11 @@ export interface JoinedEvent {
   isLike: boolean;
   isParticipated: boolean;
 }
-
-export interface MyReview {
+export interface MyReview extends ReviewerCount {
   reviewId: number;
   description: string;
   marketName: string;
   pictureUrl: string;
-  reviewerEventCount: number;
-  reviewerReviewCount: number;
 }
 
 export interface UserReview {
@@ -42,12 +74,10 @@ export interface UserReview {
   marketName: string;
   pictureUrl: string;
 }
-export interface UserReviewListOptions {
+export interface UserReviewListOptions extends ReviewerCount {
   last: boolean | null;
   totalPages: number;
   totalElements: number;
-  reviewerEventCount: number;
-  reviewerReviewCount: number;
 }
 
 export const HISTORY_LOADING = 'HISTORY/LOADING' as const;

--- a/src/contexts/userHistory/types.ts
+++ b/src/contexts/userHistory/types.ts
@@ -36,6 +36,20 @@ export interface MyReview {
   reviewerReviewCount: number;
 }
 
+export interface UserReview {
+  reviewId: number;
+  description: string;
+  marketName: string;
+  pictureUrl: string;
+}
+export interface UserReviewListOptions {
+  last: boolean | null;
+  totalPages: number;
+  totalElements: number;
+  reviewerEventCount: number;
+  reviewerReviewCount: number;
+}
+
 export const HISTORY_LOADING = 'HISTORY/LOADING' as const;
 export const INITIALIZE_HISTORY = 'HISTORY/INITIALIZE_HISTORY' as const;
 export const GET_JOINED_EVENT = 'HISTORY/GET_JOINED_EVENT' as const;
@@ -54,7 +68,8 @@ export interface InitialStateType {
   likeEventList: Array<LikeEvent> | [];
   joinedEventList: Array<JoinedEvent> | [];
   myReviewList: Array<MyReview> | [];
-  userReviewList: Array<MyReview> | [];
+  userReviewList: Array<UserReview> | [];
+  userReviewListOptions: UserReviewListOptions;
   historyError: ErrorType;
 }
 export interface ContextType extends InitialStateType {
@@ -82,5 +97,9 @@ export type Action =
     }
   | {
       type: 'HISTORY/GET_USER_REVIEWS';
-      payload: { userReviewList: MyReview[]; historyError: ErrorType };
+      payload: {
+        userReviewList: UserReview[];
+        userReviewListOptions: UserReviewListOptions;
+        historyError: ErrorType;
+      };
     };

--- a/src/pages/user/[userId]/index.tsx
+++ b/src/pages/user/[userId]/index.tsx
@@ -1,14 +1,8 @@
-import {
-  CardContainer,
-  CardList,
-  HeaderText,
-  MainContainer,
-} from '@components/atoms';
+import { CardList, HeaderText, MainContainer } from '@components/atoms';
 import { Header, ReviewCard } from '@components/domains';
 import { useUserHistory } from '@contexts/userHistory';
 import styled from '@emotion/styled';
 import { marginTop } from '@utils/computed';
-import getConvertedDate from '@utils/date';
 import { useRouter } from 'next/dist/client/router';
 import React, { useEffect } from 'react';
 
@@ -25,36 +19,6 @@ const UserDetailPage = () => {
     dispatchUserReviews(memberId);
   }, [dispatchUserReviews, memberId]);
 
-  const userReviews = [
-    {
-      reviewId: 1,
-      description:
-        '회덮밥이 너무나 맛있었어요~ 너무나 맛난 저녁에다 맥주 공짜로 먹어서 좋았어요!',
-      memberNickname: 'JengYoungTest2',
-      memberId: 0,
-      pictureUrls: ['https://picsum.photos/200'],
-      createdAt: getConvertedDate(new Date()),
-    },
-    {
-      reviewId: 1,
-      description:
-        '회덮밥이 너무나 맛있었어요~ 너무나 맛난 저녁에다 맥주 공짜로 먹어서 좋았어요!',
-      memberNickname: 'JengYoungTest2',
-      memberId: 0,
-      pictureUrls: ['https://picsum.photos/200'],
-      createdAt: getConvertedDate(new Date()),
-    },
-    {
-      reviewId: 1,
-      description:
-        '회덮밥이 너무나 맛있었어요~ 너무나 맛난 저녁에다 맥주 공짜로 먹어서 좋았어요!',
-      memberNickname: 'JengYoungTest2',
-      memberId: 0,
-      pictureUrls: ['https://picsum.photos/200'],
-      createdAt: getConvertedDate(new Date()),
-    },
-  ];
-
   return (
     <MainContainer>
       <Header isVisibleMenu isVisiblePrev />
@@ -63,10 +27,17 @@ const UserDetailPage = () => {
       </HeaderText>
       <CounterBox />
       <CardList box flexType="default" width={320} padding={0} margin={0}>
-        {userReviews.map((reviewData) => (
+        {userReviewList.map((reviewData) => (
           <ReviewCard
+            key={reviewData.marketName + reviewData.reviewId}
             cardType="box"
-            reviewData={reviewData}
+            reviewData={{
+              reviewId: reviewData.reviewId,
+              memberId: Number(memberId),
+              marketName: reviewData.marketName,
+              pictureUrl: reviewData.pictureUrl,
+              description: reviewData.description,
+            }}
             marginWidth={8}
             marginHeight={8}
           />

--- a/src/pages/user/[userId]/index.tsx
+++ b/src/pages/user/[userId]/index.tsx
@@ -3,6 +3,7 @@ import { Header, ReviewCard } from '@components/domains';
 import StateCounter from '@components/domains/StateCounter';
 import { useUserHistory } from '@contexts/userHistory';
 import styled from '@emotion/styled';
+import useLoginCheck from '@hooks/useLoginCheck';
 import { marginTop } from '@utils/computed';
 import { useRouter } from 'next/dist/client/router';
 import React, { useEffect } from 'react';
@@ -20,6 +21,14 @@ const UserDetailPage = () => {
   const { userId: memberId } = router.query;
   const { userReviewList, userReviewListOptions, dispatchUserReviews } =
     useUserHistory();
+
+  const { isFirst, handleCheck } = useLoginCheck();
+
+  useEffect(() => {
+    if (!isFirst) {
+      handleCheck(false);
+    }
+  }, [isFirst, handleCheck]);
 
   useEffect(() => {
     if (!memberId) return;

--- a/src/pages/user/[userId]/index.tsx
+++ b/src/pages/user/[userId]/index.tsx
@@ -38,7 +38,7 @@ const UserDetailPage = () => {
   return (
     <MainContainer>
       <Header isVisibleMenu isVisiblePrev />
-      <HeaderText level={1} bold block css={marginTop(42)}>
+      <HeaderText level={1} css={marginTop(42)}>
         {memberId}
       </HeaderText>
       <CounterBox>

--- a/src/pages/user/[userId]/index.tsx
+++ b/src/pages/user/[userId]/index.tsx
@@ -1,5 +1,6 @@
 import { CardList, HeaderText, MainContainer } from '@components/atoms';
 import { Header, ReviewCard } from '@components/domains';
+import StateCounter from '@components/domains/StateCounter';
 import { useUserHistory } from '@contexts/userHistory';
 import styled from '@emotion/styled';
 import { marginTop } from '@utils/computed';
@@ -7,12 +8,18 @@ import { useRouter } from 'next/dist/client/router';
 import React, { useEffect } from 'react';
 
 const CounterBox = styled.section`
+  display: flex;
+  justify-content: space-between;
+  width: 200px;
+  margin: 0 auto;
   margin-top: 40px;
+  margin-bottom: 50px;
 `;
 const UserDetailPage = () => {
   const router = useRouter();
   const { userId: memberId } = router.query;
-  const { userReviewList, dispatchUserReviews } = useUserHistory();
+  const { userReviewList, userReviewListOptions, dispatchUserReviews } =
+    useUserHistory();
 
   useEffect(() => {
     if (!memberId) return;
@@ -25,7 +32,16 @@ const UserDetailPage = () => {
       <HeaderText level={1} bold block css={marginTop(42)}>
         {memberId}
       </HeaderText>
-      <CounterBox />
+      <CounterBox>
+        <StateCounter
+          name="참여 수"
+          count={userReviewListOptions.reviewerEventCount}
+        />
+        <StateCounter
+          name="작성 리뷰 수"
+          count={userReviewListOptions.reviewerReviewCount}
+        />
+      </CounterBox>
       <CardList box flexType="default" width={320} padding={0} margin={0}>
         {userReviewList.map((reviewData) => (
           <ReviewCard

--- a/src/pages/user/[userId]/index.tsx
+++ b/src/pages/user/[userId]/index.tsx
@@ -1,10 +1,79 @@
+import {
+  CardContainer,
+  CardList,
+  HeaderText,
+  MainContainer,
+} from '@components/atoms';
+import { Header, ReviewCard } from '@components/domains';
+import { useUserHistory } from '@contexts/userHistory';
+import styled from '@emotion/styled';
+import { marginTop } from '@utils/computed';
+import getConvertedDate from '@utils/date';
 import { useRouter } from 'next/dist/client/router';
-import React from 'react';
+import React, { useEffect } from 'react';
 
+const CounterBox = styled.section`
+  margin-top: 40px;
+`;
 const UserDetailPage = () => {
   const router = useRouter();
-  const { userId } = router.query;
-  return <div>{userId} 유저 정보 조회 페이지</div>;
+  const { userId: memberId } = router.query;
+  const { userReviewList, dispatchUserReviews } = useUserHistory();
+
+  useEffect(() => {
+    if (!memberId) return;
+    dispatchUserReviews(memberId);
+  }, [dispatchUserReviews, memberId]);
+
+  const userReviews = [
+    {
+      reviewId: 1,
+      description:
+        '회덮밥이 너무나 맛있었어요~ 너무나 맛난 저녁에다 맥주 공짜로 먹어서 좋았어요!',
+      memberNickname: 'JengYoungTest2',
+      memberId: 0,
+      pictureUrls: ['https://picsum.photos/200'],
+      createdAt: getConvertedDate(new Date()),
+    },
+    {
+      reviewId: 1,
+      description:
+        '회덮밥이 너무나 맛있었어요~ 너무나 맛난 저녁에다 맥주 공짜로 먹어서 좋았어요!',
+      memberNickname: 'JengYoungTest2',
+      memberId: 0,
+      pictureUrls: ['https://picsum.photos/200'],
+      createdAt: getConvertedDate(new Date()),
+    },
+    {
+      reviewId: 1,
+      description:
+        '회덮밥이 너무나 맛있었어요~ 너무나 맛난 저녁에다 맥주 공짜로 먹어서 좋았어요!',
+      memberNickname: 'JengYoungTest2',
+      memberId: 0,
+      pictureUrls: ['https://picsum.photos/200'],
+      createdAt: getConvertedDate(new Date()),
+    },
+  ];
+
+  return (
+    <MainContainer>
+      <Header isVisibleMenu isVisiblePrev />
+      <HeaderText level={1} bold block css={marginTop(42)}>
+        {memberId}
+      </HeaderText>
+      <CounterBox />
+      <CardList box flexType="default" width={320} padding={0} margin={0}>
+        {userReviews.map((reviewData) => (
+          <ReviewCard
+            cardType="box"
+            reviewData={reviewData}
+            marginWidth={8}
+            marginHeight={8}
+          />
+        ))}
+      </CardList>
+    </MainContainer>
+  );
 };
 
 export default UserDetailPage;

--- a/src/stories/domains/ReviewCard.stories.tsx
+++ b/src/stories/domains/ReviewCard.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReviewCard from '@components/domains/ReviewCard';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import CardList from '@components/atoms/CardList';
+import getConvertedDate from '@utils/date';
 
 export default {
   title: 'Component/domains/ReviewCard',
@@ -34,7 +35,7 @@ export const Default: ComponentStory<typeof ReviewCard> = (args) => {
     memberNickname: 'JengYoungTest2',
     memberId: 0,
     pictureUrls: ['https://picsum.photos/200'],
-    createdAt: new Date(),
+    createdAt: getConvertedDate(new Date()),
   };
   return (
     <CardList box flexType="default" width={320} padding={0} margin={0}>


### PR DESCRIPTION
## 커밋 설명:
  유저 정보 조회 페이지에 관한 레이아웃 및 상세 로직을 구현한다.
![image](https://user-images.githubusercontent.com/78713176/147642657-9d711101-3f3b-4f7d-b372-20f2d1e58f74.png)

## 체크 리스트:
  - [x] 유저는 유저 정보 페이지에서 해당 유저가 작성한 리뷰를 볼 수 있다.
  - [x] 유저의 리뷰는 테스트 코드가 아닌 API 응답 결과로 반영된다.
  - [x] 유저 정보 페이지에서는 참여 수 및 리뷰를 작성한 수를 확인할 수 있다.
  - [x] 유저의 카드에는 API 응답에 담긴 데이터가 모두 반영된다.

## 주의 사항:
  - 익명의 유저도 조회가 가능한 페이지이나, 현재 로그인이 되어 있지 않을 경우 조회가 불가능한 현상이 발생한다.
  - 일정하게 나올 수 있는 reviewData가 기존에 작성한 리뷰 응답 값과 key, value type이 일치하지 않는 문제가 발생한다.
  - memberId는 찾을 수 있으나, memberNickname을 조회할 수 없는 현상이 발생하고 있다.

## 향후 예정:
  - 위와 같은 예외 사항에 대한 처리를 백엔드에 요청한다.