### PR TITLE
[TLVB-233] 주소 검색 API 도입 및 적용

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,7 @@ module.exports = {
     '@next/next/no-page-custom-font': 'off',
     '@typescript-eslint/no-unused-vars': [2, { args: 'none' }],
     'no-param-reassign': 'off',
+    'react/prop-types': 'off',
   },
   globals: {
     React: true,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "postcss": "^8.4.4",
     "postcss-scss": "^4.0.2",
     "react": "17.0.2",
+    "react-daum-postcode": "^3.0.1",
     "react-dom": "17.0.2",
     "react-icons": "^4.3.1"
   },

--- a/src/components/domains/PostCode.tsx
+++ b/src/components/domains/PostCode.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import DaumPostcode, { Address } from 'react-daum-postcode';
+
+const PostCode = ({ ...props }) => {
+  const handleComplete = (data: Address) => {
+    let fullAddress = data.address;
+    let extraAddress = '';
+    if (data.addressType === 'R') {
+      if (data.bname !== '') {
+        extraAddress += data.bname;
+      }
+      if (data.buildingName !== '') {
+        extraAddress +=
+          extraAddress !== '' ? `, ${data.buildingName}` : data.buildingName;
+      }
+      fullAddress += extraAddress !== '' ? ` (${extraAddress})` : '';
+    }
+
+    console.log(fullAddress); // e.g. '서울 성동구 왕십리로2길 20 (성수동1가)'
+  };
+
+  return <DaumPostcode onComplete={handleComplete} {...props} />;
+};
+
+export default PostCode;

--- a/src/components/domains/PostCode.tsx
+++ b/src/components/domains/PostCode.tsx
@@ -1,25 +1,43 @@
-import React from 'react';
+import styled from '@emotion/styled';
+import React, { SetStateAction } from 'react';
 import DaumPostcode, { Address } from 'react-daum-postcode';
 
-const PostCode = ({ ...props }) => {
-  const handleComplete = (data: Address) => {
-    let fullAddress = data.address;
-    let extraAddress = '';
-    if (data.addressType === 'R') {
-      if (data.bname !== '') {
-        extraAddress += data.bname;
-      }
-      if (data.buildingName !== '') {
-        extraAddress +=
-          extraAddress !== '' ? `, ${data.buildingName}` : data.buildingName;
-      }
-      fullAddress += extraAddress !== '' ? ` (${extraAddress})` : '';
-    }
+const StyledPostcode = styled.div`
+  width: 300px;
+  height: calc(100%);
+`;
 
-    console.log(fullAddress); // e.g. '서울 성동구 왕십리로2길 20 (성수동1가)'
+interface TPostCode {
+  onChangeAddressInput: (address: string) => void;
+  setShowPostCode: React.Dispatch<SetStateAction<boolean>>;
+  setModalVisible: React.Dispatch<SetStateAction<boolean>>;
+  autoClose: boolean;
+}
+
+const PostCode = ({
+  onChangeAddressInput,
+  setShowPostCode,
+  setModalVisible,
+  ...props
+}: TPostCode) => {
+  const handleComplete = (data: Address) => {
+    const address = `${data.sido} ${data.sigungu} ${data.bname}`;
+
+    onChangeAddressInput(address);
+    setShowPostCode(() => false);
+
+    return address;
   };
 
-  return <DaumPostcode onComplete={handleComplete} {...props} />;
+  return (
+    <StyledPostcode>
+      <DaumPostcode
+        style={{ height: '100%' }}
+        onComplete={handleComplete}
+        {...props}
+      />
+    </StyledPostcode>
+  );
 };
 
 export default PostCode;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -57,7 +57,7 @@ const AddressButtonBox = styled.div`
   padding: 0 1rem;
 `;
 const StyledAddressInfo = styled.address`
-  margin-top: 1rem;
+  margin-top: 2rem;
   margin-bottom: 1rem;
   text-align: center;
   text-decoration: normal;
@@ -276,18 +276,12 @@ const MainPage: NextPage = () => {
         clickAway
       >
         <HeaderText level={1} marginBottom={20}>
-          주소 등록
+          {addressValue ? '주소 확인' : '주소 등록'}
         </HeaderText>
-        <HeaderText level={2} marginBottom={16}>
-          어떤 곳의 이벤트를 찾고 싶나요?
-        </HeaderText>
-        {addressValue && (
-          <StyledAddressInfo>
-            <Text bold block size="large">
-              {addressValue}
-            </Text>
-            에서의 이벤트를 찾으시겠어요?
-          </StyledAddressInfo>
+        {!addressValue && (
+          <HeaderText level={2} marginBottom={16}>
+            어떤 곳의 이벤트를 찾고 싶나요?
+          </HeaderText>
         )}
         {modalVisible && showPostCode && (
           <PostCode
@@ -298,17 +292,28 @@ const MainPage: NextPage = () => {
           />
         )}
         {addressValue && (
-          <AddressButtonBox>
-            <Button onClick={handleSubmitAddress} css={AddressSubmitButtonCSS}>
-              주소 등록하기
-            </Button>
-            <Button
-              onClick={handleReSearchAddress}
-              css={AddressResearchButtonCSS}
-            >
-              주소 다시 찾기
-            </Button>
-          </AddressButtonBox>
+          <>
+            <StyledAddressInfo>
+              <Text bold block size="large">
+                {addressValue}
+              </Text>
+              에서의 이벤트를 찾으시겠어요?
+            </StyledAddressInfo>
+            <AddressButtonBox>
+              <Button
+                onClick={handleSubmitAddress}
+                css={AddressSubmitButtonCSS}
+              >
+                주소 등록하기
+              </Button>
+              <Button
+                onClick={handleReSearchAddress}
+                css={AddressResearchButtonCSS}
+              >
+                주소 다시 찾기
+              </Button>
+            </AddressButtonBox>
+          </>
         )}
       </Modal>
     </>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -24,6 +24,7 @@ import {
 import { setStorage } from '@utils/storage';
 import { USER_ADDRESS_KEY } from '@utils/constantUser';
 import useLoginCheck from '@hooks/useLoginCheck';
+import PostCode from '@components/domains/PostCode';
 
 const AddressButtonCSS = css`
   margin-top: 60px;
@@ -250,12 +251,13 @@ const MainPage: NextPage = () => {
         <HeaderText level={2} marginBottom={16}>
           어떤 곳의 이벤트를 찾고 싶나요?
         </HeaderText>
-        <Input
+        <PostCode />
+        {/* <Input
           sizeType="small"
           placeholder="OO시 OO구 OO동으로 입력"
           error={false}
           onChange={handleChangeAddressInput}
-        />
+        /> */}
         <Button onClick={handleSubmitAddress} css={AddressSubmitButtonCSS}>
           주소 등록하기
         </Button>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -102,6 +102,8 @@ const MainPage: NextPage = () => {
   const handleSubmitAddress = (e: React.MouseEvent) => {
     e.preventDefault();
     setUserAddress(() => addressValue);
+    setAddressValue(() => '');
+    setShowPostCode(() => true);
     setModalVisible(() => false);
   };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,17 +14,12 @@ import styles from '@styles/index';
 import type { NextPage } from 'next';
 import React, { useEffect, useCallback, useState, useRef } from 'react';
 import { useRouter } from 'next/router';
-import {
-  CardContainer,
-  HeaderText,
-  Input,
-  Modal,
-  Text,
-} from '@components/atoms';
+import { CardContainer, HeaderText, Modal, Text } from '@components/atoms';
 import { setStorage } from '@utils/storage';
 import { USER_ADDRESS_KEY } from '@utils/constantUser';
 import useLoginCheck from '@hooks/useLoginCheck';
 import PostCode from '@components/domains/PostCode';
+import styled from '@emotion/styled';
 
 const AddressButtonCSS = css`
   margin-top: 60px;
@@ -33,8 +28,14 @@ const AddressButtonCSS = css`
 `;
 
 const AddressSubmitButtonCSS = css`
-  position: absolute;
-  bottom: 24px;
+  left: 0;
+  width: 48%;
+`;
+
+const AddressResearchButtonCSS = css`
+  ${AddressSubmitButtonCSS}
+  right: 0;
+  left: auto;
 `;
 
 const NoEventListCardCSS = css`
@@ -47,8 +48,24 @@ const NoEventListCardCSS = css`
   }
 `;
 
+const AddressButtonBox = styled.div`
+  position: absolute;
+  bottom: 24px;
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  padding: 0 1rem;
+`;
+const StyledAddressInfo = styled.address`
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  text-align: center;
+  text-decoration: normal;
+`;
+
 const MainPage: NextPage = () => {
   const [modalVisible, setModalVisible] = useState(false);
+  const [showPostCode, setShowPostCode] = useState(true);
 
   const { isFirst, handleCheck } = useLoginCheck();
 
@@ -67,8 +84,10 @@ const MainPage: NextPage = () => {
     dispatchEventList,
     initializeEventList,
   } = useEvent();
+
   const [sortState, setSortState] = useState<SortOrder>('desc');
   const [sortTypeState, setSortTypeState] = useState<SortType>('createdAt');
+
   const router = useRouter();
 
   const handleCardClick = (eventId: string) => {
@@ -76,12 +95,20 @@ const MainPage: NextPage = () => {
   };
 
   const handleChangeAddressInput = useCallback((e) => {
-    setAddressValue(() => e.target.value);
+    setAddressValue(() => e);
+    // setAddressValue(() => e.target.value);
   }, []);
 
   const handleSubmitAddress = (e: React.MouseEvent) => {
     e.preventDefault();
     setUserAddress(() => addressValue);
+    setModalVisible(() => false);
+  };
+
+  const handleReSearchAddress = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setAddressValue(() => '');
+    setShowPostCode(() => true);
   };
 
   const closeModal = () => {
@@ -120,6 +147,7 @@ const MainPage: NextPage = () => {
     sortState,
     sortTypeState,
   ]);
+
   useEffect(() => {
     return () => {
       setUserAddress(() => null);
@@ -238,7 +266,7 @@ const MainPage: NextPage = () => {
       </MainContainer>
       <Modal
         width={300}
-        height={256}
+        height={addressValue ? 280 : 600}
         modalType="default"
         padding={24}
         visible={modalVisible}
@@ -251,16 +279,35 @@ const MainPage: NextPage = () => {
         <HeaderText level={2} marginBottom={16}>
           어떤 곳의 이벤트를 찾고 싶나요?
         </HeaderText>
-        <PostCode />
-        {/* <Input
-          sizeType="small"
-          placeholder="OO시 OO구 OO동으로 입력"
-          error={false}
-          onChange={handleChangeAddressInput}
-        /> */}
-        <Button onClick={handleSubmitAddress} css={AddressSubmitButtonCSS}>
-          주소 등록하기
-        </Button>
+        {addressValue && (
+          <StyledAddressInfo>
+            <Text bold block size="large">
+              {addressValue}
+            </Text>
+            에서의 이벤트를 찾으시겠어요?
+          </StyledAddressInfo>
+        )}
+        {modalVisible && showPostCode && (
+          <PostCode
+            autoClose
+            onChangeAddressInput={handleChangeAddressInput}
+            setShowPostCode={setShowPostCode}
+            setModalVisible={setModalVisible}
+          />
+        )}
+        {addressValue && (
+          <AddressButtonBox>
+            <Button onClick={handleSubmitAddress} css={AddressSubmitButtonCSS}>
+              주소 등록하기
+            </Button>
+            <Button
+              onClick={handleReSearchAddress}
+              css={AddressResearchButtonCSS}
+            >
+              주소 다시 찾기
+            </Button>
+          </AddressButtonBox>
+        )}
       </Modal>
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -9964,6 +9964,14 @@ react-colorful@^5.1.2:
   resolved "https://registry.yarnpkg.com/react-colorful/-/react-colorful-5.5.1.tgz#29d9c4e496f2ca784dd2bb5053a3a4340cfaf784"
   integrity sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==
 
+react-daum-postcode@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-daum-postcode/-/react-daum-postcode-3.0.1.tgz#1d87145a4c82fe107ad041c855b857e45c0555e1"
+  integrity sha512-TBA6p+5yFy4YrH3jneNPyqNR+9igCb/XhQfnDBOABX38Hgf4n5EMmXf3NZptPSqg3UldHQ+8HPHCJ5L6zjskkg==
+  dependencies:
+    prop-types "^15.7.2"
+    react "^17.0.2"
+
 react-dev-utils@^11.0.3:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/react-dev-utils/-/react-dev-utils-11.0.4.tgz#a7ccb60257a1ca2e0efe7a83e38e6700d17aa37a"
@@ -10153,7 +10161,7 @@ react-textarea-autosize@^8.3.0:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react@17.0.2:
+react@17.0.2, react@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==


### PR DESCRIPTION
# PR 설명

주소 검색 API를 사용하여 유저 주소를 받는 로직의 UX를 강화한다.

## 사용 API

크게 2가지 관점에서 Daum에서 제공하는 주소 API를 등록하였습니다.

1. 안정성 - 프론트엔드단에서 직접 처리해도 보안성에 있어서 무방한가?
2. 제공할 수 있는 자원의 양 - API를 무료로 사용하여 사용자에게 지속하여 제공할 수 있는가?

따라서 해당 2가지 관점에서 볼 때 가장 적합하다고 생각하여 `DaumPostCode` 패키지를 설치하여 구현하였습니다.

## 체크리스트
- [x] 사용자는 주소를 검색하여 입력할 수 있다.
- [x] 사용자는 주소를 선택하여 시, 군, 구 / 동의 형식으로만 주소를 입력하게 된다.
- [x] 사용자는 원하지 않는 주소라면 주소를 다시 선택할 수 있다. 

## 영상 시
https://user-images.githubusercontent.com/78713176/151666379-e7a2950a-79c9-4e23-9a6e-35336456056f.mov

# 주의사항
반드시 이후에 `yarn install`을 해주시길 부탁드립니다~!