### PR TITLE
[TLVB-229] 가게보기 이벤트리스트 페이지네이션 구현

### DIFF
--- a/src/components/domains/Pagination.tsx
+++ b/src/components/domains/Pagination.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import Common from '@styles/index';
+
+const PaginationContainer = styled.ul`
+  padding: 1px;
+  color: ${Common.colors.background};
+  text-align: center;
+  list-style: none;
+`;
+
+const PaginationItem = styled.li`
+  display: inline-block;
+  width: 24px;
+  padding: 4px;
+  margin-right: 4px;
+  font-size: ${Common.fontSize.medium};
+  color: ${Common.colors.point};
+  border: 1px solid ${Common.colors.point};
+  border-radius: 4px;
+`;
+
+const SelectedPageItem = styled(PaginationItem)`
+  color: ${Common.colors.background};
+  background-color: ${Common.colors.point};
+`;
+
+interface PaginationProps {
+  eventCount: number;
+  totalEventCount: number;
+  currentPage: number;
+  paginate: (pageNumber: number) => void;
+}
+
+const Pagination = ({
+  eventCount,
+  totalEventCount,
+  currentPage,
+  paginate,
+}: PaginationProps) => {
+  const pageNumbers = [];
+  const totalPageCount = Math.ceil(totalEventCount / eventCount);
+
+  for (let i = 1; i <= totalPageCount; i += 1) {
+    pageNumbers.push(i);
+  }
+
+  return (
+    <PaginationContainer>
+      {pageNumbers.map((pageNumber) =>
+        currentPage !== pageNumber ? (
+          <PaginationItem key={pageNumber} onClick={() => paginate(pageNumber)}>
+            {pageNumber}
+          </PaginationItem>
+        ) : (
+          <SelectedPageItem
+            key={pageNumber}
+            onClick={() => paginate(pageNumber)}
+          >
+            {pageNumber}
+          </SelectedPageItem>
+        )
+      )}
+    </PaginationContainer>
+  );
+};
+
+export default Pagination;

--- a/src/components/domains/ShopDetail/ShopEvents.tsx
+++ b/src/components/domains/ShopDetail/ShopEvents.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { CardList } from '@components/atoms';
-import { EventCard } from '@components/domains';
+import { EventCard, Pagination } from '@components/domains';
 import { ShopEvent } from '@contexts/Shop/types';
 import { ShopContext } from '@contexts/Shop';
 import { useRouter } from 'next/router';
@@ -12,6 +12,8 @@ interface ShopEventsProps extends Partial<ShopEvent> {
 const ShopEvents = ({ marketId }: ShopEventsProps) => {
   const { getShopEvents } = useContext(ShopContext);
   const [eventInfo, setEventInfo] = useState([]);
+  const eventCount: number = 3;
+  const [currentPage, setCurrentPage] = useState(1);
 
   const router = useRouter();
 
@@ -27,22 +29,33 @@ const ShopEvents = ({ marketId }: ShopEventsProps) => {
     }
   }, [getShopEvents, marketId]);
 
-  const defaultData = {
-    like: true,
+  const showCurrentEvents = () => {
+    const endIndex: number = currentPage * eventCount;
+    const startIndex: number = endIndex - eventCount;
+
+    return eventInfo.slice(startIndex, endIndex);
   };
 
   return (
-    <CardList flexType="column" padding={0} margin="10px 0 0 0">
-      {eventInfo.map((event: any, index: number) => (
-        <EventCard
-          onClick={() => handleClick(event.eventId)}
-          key={`${`${event}${index}`}`}
-          eventData={{ ...defaultData, ...event }}
-          idx={index}
-          marginHeight={10}
-        />
-      ))}
-    </CardList>
+    <>
+      <CardList flexType="column" padding={0} margin="10px 0 0 0">
+        {showCurrentEvents().map((event: any, index: number) => (
+          <EventCard
+            onClick={() => handleClick(event.eventId)}
+            key={`${`${event}${index}`}`}
+            eventData={event}
+            idx={index}
+            marginHeight={10}
+          />
+        ))}
+      </CardList>
+      <Pagination
+        eventCount={eventCount}
+        totalEventCount={eventInfo.length}
+        currentPage={currentPage}
+        paginate={setCurrentPage}
+      />
+    </>
   );
 };
 

--- a/src/components/domains/index.ts
+++ b/src/components/domains/index.ts
@@ -12,6 +12,7 @@ export { default as ProfileEdit } from './ProfileEdit';
 export { default as PasswordForm } from './PasswordForm';
 export { default as Tab } from './Tab';
 export { default as LoginInformContainer } from './ControlModal/LoginInformContainer';
+export { default as Pagination } from './Pagination';
 export * from './EventDetail/index';
 
 /* eslint-disable import/no-cycle */


### PR DESCRIPTION
## 구현사항
* 사업자의 가게보기 페이지에서 이벤트 리스트 페이지네이션 기능 구현
![shop_pagination](https://user-images.githubusercontent.com/71805803/150651655-77fcd248-d5b7-4749-b1fb-7a24367671f7.gif)


## 참고사항
* 페이지 클릭 시 이벤트 리스트에 스크롤이 유지되어있어야하므로 page/shop/index가 아닌 components/domains/ShopEvents에서 import하였습니다.
* 이벤트는 한 페이지당 3개씩 보여주게 구현하였습니다.